### PR TITLE
Change how chat sessions are spawned

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -63,6 +63,8 @@ if config_env() == :prod do
     ],
     secret_key_base: secret_key_base
 
+  config :slippi_chat, :chat_session_timeout_ms, :timer.minutes(15)
+
   # ## SSL Support
   #
   # To get SSL working, you will need to add the `https` key

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -64,6 +64,7 @@ if config_env() == :prod do
     secret_key_base: secret_key_base
 
   config :slippi_chat, :chat_session_timeout_ms, :timer.minutes(15)
+  config :slippi_chat, :chat_session_registry, SlippiChat.ChatSessionRegistry
 
   # ## SSL Support
   #

--- a/config/test.exs
+++ b/config/test.exs
@@ -23,6 +23,8 @@ config :slippi_chat, SlippiChatWeb.Endpoint,
 # In test we don't send emails.
 config :slippi_chat, SlippiChat.Mailer, adapter: Swoosh.Adapters.Test
 
+config :slippi_chat, :chat_session_timeout_ms, 100
+
 # Disable swoosh api client as it is only required for production adapters.
 config :swoosh, :api_client, false
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -23,7 +23,7 @@ config :slippi_chat, SlippiChatWeb.Endpoint,
 # In test we don't send emails.
 config :slippi_chat, SlippiChat.Mailer, adapter: Swoosh.Adapters.Test
 
-config :slippi_chat, :chat_session_timeout_ms, 100
+config :slippi_chat, :chat_session_timeout_ms, 150
 
 # Disable swoosh api client as it is only required for production adapters.
 config :swoosh, :api_client, false

--- a/lib/slippi_chat/application.ex
+++ b/lib/slippi_chat/application.ex
@@ -14,6 +14,8 @@ defmodule SlippiChat.Application do
       SlippiChat.Repo,
       # Start the PubSub system
       {Phoenix.PubSub, name: SlippiChat.PubSub},
+      # Start Presence
+      SlippiChatWeb.Presence,
       # Start Finch
       {Finch, name: SlippiChat.Finch},
       # Start the Endpoint (http/https)

--- a/lib/slippi_chat/application.ex
+++ b/lib/slippi_chat/application.ex
@@ -22,9 +22,7 @@ defmodule SlippiChat.Application do
       SlippiChatWeb.Endpoint,
       # Start a worker by calling: SlippiChat.Worker.start_link(arg)
       # {SlippiChat.Worker, arg}
-      # TODO: Link the following 2 children so they die together but don't bring everything else down
-      {DynamicSupervisor, name: SlippiChat.ChatSessionSupervisor, strategy: :one_for_one},
-      {SlippiChat.ChatSessionRegistry, name: SlippiChat.ChatSessionRegistry}
+      {SlippiChat.ChatSessions.Supervisor, name: SlippiChat.ChatSessions.Supervisor}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/slippi_chat/chat_session_registry.ex
+++ b/lib/slippi_chat/chat_session_registry.ex
@@ -1,30 +1,16 @@
-# TODO: If this genserver crashes, we need the ETS table to drop
 defmodule SlippiChat.ChatSessionRegistry do
+  @moduledoc """
+  This module creates an ETS table, named the same as the GenServer name.
+
+  Format: player code => chat session PID
+  """
+
   use GenServer
 
+  alias SlippiChat.ChatSessions
   alias SlippiChat.ChatSessions.ChatSession
 
   require Logger
-
-  @pubsub_name SlippiChat.PubSub
-  @pubsub_topic "chat_sessions"
-
-  @moduledoc """
-  This module creates an ETS table, named the same as the GenServer name.
-  The ETS table is a mapping of player code to information about the current
-  state of the player.
-
-  Format:
-
-  player_code => %{
-    current_game: list(player_code),
-    current_chat_session: %{
-      pid: pid()
-      players: list(player_code),
-      uuid: uuid()
-    }
-  }
-  """
 
   ## Client API
 
@@ -34,200 +20,96 @@ defmodule SlippiChat.ChatSessionRegistry do
   `:name` is always required.
   """
   def start_link(opts) do
-    server = Keyword.fetch!(opts, :name)
-    GenServer.start_link(__MODULE__, server, opts)
+    server_name = Keyword.fetch!(opts, :name)
+    GenServer.start_link(__MODULE__, server_name, opts)
   end
 
   @doc """
-  Looks up the metadata for `player_code` stored in `server`.
+  Looks up the chat session for `player_code` stored in `server`.
 
-  Returns `{:ok, data}` if the bucket exists, `:error` otherwise.
+  Returns `{:ok, pid}` if the entry exists, `:error` otherwise.
   """
   def lookup(server, player_code) do
     case :ets.lookup(server, player_code) do
-      [{^player_code, data}] -> {:ok, data}
+      [{^player_code, pid}] -> {:ok, pid}
       [] -> :error
     end
   end
 
-  @doc """
-  Ensure the client code is registered in the server.
-  """
-  def register_client(server, client_code) do
-    GenServer.call(server, {:register_client, client_code})
+  def start_chat_session(server, player_codes) do
+    GenServer.call(server, {:start_chat_session, player_codes})
   end
 
-  @doc """
-  Ensure the client code is not registered in the server.
-  """
-  def remove_client(server, client_code) do
-    GenServer.call(server, {:remove_client, client_code})
-  end
-
-  @doc """
-  Handle a game being started for a client. Starts or stops sessions accordingly.
-  """
-  def game_started(server, client_code, players) do
-    GenServer.call(server, {:game_started, client_code, players})
-  end
-
-  @doc """
-  Handle a game ending for a client.
-  """
-  def game_ended(server, client_code) do
-    GenServer.call(server, {:game_ended, client_code})
-  end
-
-  ## Server callbacks
+  ## Callbacks
 
   @impl true
-  def init(table) do
-    players_ets = :ets.new(table, [:named_table, read_concurrency: true])
+  def init(table_name) do
+    players_ets = :ets.new(table_name, [:named_table, read_concurrency: true])
     refs = %{}
     {:ok, {players_ets, refs}}
   end
 
   @impl true
-  def handle_call({:register_client, client_code}, _from, {players_ets, _refs} = state) do
-    if lookup(players_ets, client_code) == :error do
-      data = %{current_game: nil, current_chat_session: nil}
-      :ets.insert(players_ets, {client_code, data})
-    end
+  def handle_call({:start_chat_session, player_codes}, _from, {players_ets, refs} = state) do
+    case DynamicSupervisor.start_child(SlippiChat.ChatSessionSupervisor, {ChatSession, player_codes}) do
+      {:error, {:already_started, pid}} ->
+        {:reply, {:already_started, pid}, state}
 
-    {:reply, :ok, state}
-  end
+      {:ok, pid} ->
+        ref = Process.monitor(pid)
+        new_refs = Map.put(refs, ref, player_codes)
 
-  def handle_call({:remove_client, client_code}, _from, {players_ets, _refs} = state) do
-    with {:ok, data} <- lookup(players_ets, client_code) do
-      :ets.delete(players_ets, client_code)
+        end_existing_sessions(players_ets, player_codes)
 
-      with %{current_chat_session: %{pid: pid}} <- data do
-        ChatSession.end_session(pid)
-      end
-    end
+        Enum.each(player_codes, fn player_code ->
+          :ets.insert(players_ets, {player_code, pid})
+        end)
 
-    {:reply, :ok, state}
-  end
-
-  def handle_call({:game_started, client_code, players}, _from, {players_ets, refs}) do
-    Logger.debug("Game started for client #{client_code}: #{inspect(players)}")
-    update_client_data(players_ets, client_code, players)
-    player_data = get_player_data(players_ets, players)
-    stop_old_sessions(player_data, players)
-
-    if should_start_session(player_data, client_code, players) do
-      {pid, new_refs} = start_session(players_ets, refs, player_data, players)
-
-      {:reply, {:ok, pid}, {players_ets, new_refs},
-       {:continue, {:notify_subscribers, [:session, :start], {players, pid}}}}
-    else
-      {:reply, :ok, {players_ets, refs}}
+        {:reply, {:ok, pid}, {players_ets, new_refs},
+         {:continue, {:notify_subscribers, [:session, :start], {player_codes, pid}}}}
     end
   end
 
-  def handle_call({:game_ended, client_code}, _from, {players_ets, _refs} = state) do
-    Logger.debug("Game ended for client #{client_code}")
+  defp end_existing_sessions(players_ets, player_codes) when is_list(player_codes) do
+    Enum.each(player_codes, &(end_existing_session(players_ets, &1)))
+  end
 
-    with {:ok, data} <- lookup(players_ets, client_code) do
-      new_data = put_in(data.current_game, nil)
-      :ets.insert(players_ets, {client_code, new_data})
+  defp end_existing_session(players_ets, player_code) when is_binary(player_code) do
+    with {:ok, pid} <- lookup(players_ets, player_code) do
+      if Process.alive?(pid), do: ChatSession.end_session(pid)
     end
-
-    {:reply, :ok, state}
-  end
-
-  defp get_player_data(players_ets, players) do
-    Enum.reduce(players, %{}, fn player_code, acc ->
-      case lookup(players_ets, player_code) do
-        {:ok, data} -> Map.put(acc, player_code, data)
-        :error -> Map.put(acc, player_code, nil)
-      end
-    end)
-  end
-
-  defp update_client_data(players_ets, client_code, players) do
-    {:ok, %{current_chat_session: client_chat_session}} = lookup(players_ets, client_code)
-    new_client_data = %{current_game: players, current_chat_session: client_chat_session}
-    :ets.insert(players_ets, {client_code, new_client_data})
-  end
-
-  defp stop_old_sessions(player_data, players) do
-    Enum.each(players, fn player_code ->
-      with data when not is_nil(data) <- player_data[player_code],
-           %{current_chat_session: %{pid: pid, players: current_session_players}} <- data do
-        if Process.alive?(pid) && current_session_players != players do
-          ChatSession.end_session(pid)
-        end
-      end
-    end)
-  end
-
-  defp should_start_session(player_data, client_code, players) do
-    if get_in(player_data, [client_code, :current_chat_session, :players]) != players do
-      Enum.all?(players, fn player_code ->
-        with data when not is_nil(data) <- player_data[player_code] do
-          %{current_game: current_game} = data
-          current_game == players
-        end
-      end)
-    else
-      false
-    end
-  end
-
-  defp start_session(players_ets, refs, player_data, players) do
-    {:ok, pid} =
-      DynamicSupervisor.start_child(
-        SlippiChat.ChatSessionSupervisor,
-        SlippiChat.ChatSessions.ChatSession
-      )
-
-    ref = Process.monitor(pid)
-    new_refs = Map.put(refs, ref, players)
-
-    Enum.each(players, fn player_code ->
-      if data = player_data[player_code] do
-        # TODO: uuid
-        data = put_in(data.current_chat_session, %{pid: pid, players: players, uuid: nil})
-        :ets.insert(players_ets, {player_code, data})
-      end
-    end)
-
-    {pid, new_refs}
   end
 
   @impl true
-  def handle_info({:DOWN, ref, :process, pid, _reason}, {players_ets, refs}) do
-    {players, refs} = Map.pop(refs, ref)
+  def handle_info({:DOWN, ref, :process, down_pid, reason}, {players_ets, refs}) do
+    {player_codes, refs} = Map.pop(refs, ref)
+    Logger.info("Registry got DOWN, player codes: #{inspect(player_codes)}, reason: #{inspect(reason)}")
 
-    Enum.each(players, fn player_code ->
-      with {:ok, data} <- lookup(players_ets, player_code) do
-        new_data = Map.put(data, :current_chat_session, nil)
-        :ets.insert(players_ets, {player_code, new_data})
+    Enum.each(player_codes, fn player_code ->
+      with {:ok, result_pid} <- lookup(players_ets, player_code) do
+        if result_pid == down_pid do
+          :ets.delete(players_ets, player_code)
+        end
       end
     end)
 
     {:noreply, {players_ets, refs},
-     {:continue, {:notify_subscribers, [:session, :end], {players, pid}}}}
+     {:continue, {:notify_subscribers, [:session, :end], {player_codes, down_pid}}}}
   end
 
   @impl true
   def handle_continue(
-        {:notify_subscribers, [:session, _action] = event, {players, _pid} = result},
+        {:notify_subscribers, [:session, _action] = event, {player_codes, _pid} = result},
         state
       ) do
-    Enum.each(players, fn player_code ->
+    Enum.each(player_codes, fn player_code ->
       Phoenix.PubSub.broadcast(
-        @pubsub_name,
-        topic(player_code),
+        SlippiChat.PubSub,
+        ChatSessions.player_topic(player_code),
         {event, result}
       )
     end)
 
     {:noreply, state}
-  end
-
-  defp topic(player_code) when is_binary(player_code) do
-    "#{@pubsub_topic}:#{player_code}"
   end
 end

--- a/lib/slippi_chat/chat_sessions.ex
+++ b/lib/slippi_chat/chat_sessions.ex
@@ -1,0 +1,16 @@
+defmodule SlippiChat.ChatSessions do
+  @pubsub_topic "chat_sessions"
+
+  def player_topic(player_code) when is_binary(player_code) do
+    "#{@pubsub_topic}:#{String.upcase(player_code)}"
+  end
+
+  def chat_session_topic(player_codes) when is_list(player_codes) do
+    suffix =
+      Enum.map(player_codes, &String.upcase/1)
+      |> Enum.sort()
+      |> Enum.join(",")
+
+    "#{@pubsub_topic}:#{suffix}"
+  end
+end

--- a/lib/slippi_chat/chat_sessions/chat_session.ex
+++ b/lib/slippi_chat/chat_sessions/chat_session.ex
@@ -18,7 +18,7 @@ defmodule SlippiChat.ChatSessions.ChatSession do
 
   def start_link(player_codes) do
     player_codes = standardize(player_codes)
-    GenServer.start_link(__MODULE__, player_codes, name: {:global, player_codes})
+    GenServer.start_link(__MODULE__, player_codes, name: {:global, {__MODULE__, player_codes}})
   end
 
   def get_player_codes(server) do

--- a/lib/slippi_chat/chat_sessions/chat_session.ex
+++ b/lib/slippi_chat/chat_sessions/chat_session.ex
@@ -2,31 +2,39 @@ defmodule SlippiChat.ChatSessions.ChatSession do
   @moduledoc """
   A chat session between a group of players.
   """
-  use GenServer
+  use GenServer, restart: :transient
 
-  @pubsub_name SlippiChat.PubSub
-  @pubsub_topic "chat_sessions"
+  require Logger
 
-  # TODO: uuid doesn't need to be here? It can be all handled by the registry
-  defstruct uuid: nil, messages: [], players: nil
+  alias SlippiChat.ChatSessions
+
+  # TODO: More session end conditions
+  # - send event on slippi quit out, quit when last player disconnects
+  # - send event on client quit out, via Channel terminate/2
+
+  defstruct messages: [], player_codes: nil, timeout_ref: nil
 
   ## Client API
 
-  def start_link(players) do
-    GenServer.start_link(__MODULE__, players)
+  def start_link(player_codes) do
+    player_codes = standardize(player_codes)
+    GenServer.start_link(__MODULE__, player_codes, name: {:global, player_codes})
   end
 
-  # TODO: I don't like this
-  def get_uuid(server) do
-    GenServer.call(server, :get_uuid)
+  def get_player_codes(server) do
+    GenServer.call(server, :get_player_codes)
   end
 
   def send_message(server, message) do
-    GenServer.call(server, {:message, message})
+    GenServer.call(server, {:send_message, message})
   end
 
   def list_messages(server) do
     GenServer.call(server, :list_messages)
+  end
+
+  def reset_timeout(server) do
+    GenServer.cast(server, :reset_timeout)
   end
 
   def end_session(server) do
@@ -36,18 +44,18 @@ defmodule SlippiChat.ChatSessions.ChatSession do
   ## Callbacks
 
   @impl true
-  def init(players) do
-    {:ok, %__MODULE__{uuid: Ecto.UUID.generate(), players: players}}
+  def init(player_codes) do
+    {:ok, %__MODULE__{player_codes: player_codes} |> set_timeout()}
   end
 
   @impl true
-  def handle_call(:get_uuid, _from, state) do
-    {:reply, {:ok, state.uuid}, state}
+  def handle_call({:send_message, new_message}, _from, state) do
+    {:reply, {:ok, new_message}, %{state | messages: [new_message | state.messages]} |> set_timeout(),
+     {:continue, {:notify_subscribers, [:session, :message], new_message}}}
   end
 
-  def handle_call({:message, new_message}, _from, state) do
-    {:reply, {:ok, new_message}, %{state | messages: [new_message | state.messages]},
-     {:continue, {:notify_subscribers, [:session, :message], new_message}}}
+  def handle_call(:get_player_codes, _from, state) do
+    {:reply, state.player_codes, state}
   end
 
   def handle_call(:list_messages, _from, state) do
@@ -55,17 +63,47 @@ defmodule SlippiChat.ChatSessions.ChatSession do
   end
 
   @impl true
+  def handle_cast(:reset_timeout, state) do
+    {:noreply, set_timeout(state)}
+  end
+
+  @impl true
+  def handle_info(:timeout, state) do
+    Logger.info("Session #{inspect(state.player_codes)} timed out")
+    {:stop, :normal, state}
+  end
+
+  @impl true
   def handle_continue({:notify_subscribers, [:session, _action] = event, result}, state) do
     Phoenix.PubSub.broadcast(
-      @pubsub_name,
-      topic(state.uuid),
+      SlippiChat.PubSub,
+      ChatSessions.chat_session_topic(state.player_codes),
       {event, result}
     )
 
     {:noreply, state}
   end
 
-  defp topic(uuid) when is_binary(uuid) do
-    "#{@pubsub_topic}:#{uuid}"
+  ## Helpers
+
+  defp standardize(player_codes) when is_list(player_codes) do
+    Enum.map(player_codes, &standardize/1)
+    |> Enum.sort()
+  end
+
+  defp standardize(player_code) when is_binary(player_code) do
+    String.upcase(player_code)
+  end
+
+  defp set_timeout(%{timeout_ref: ref} = state) do
+    if is_reference(ref) do
+      Process.cancel_timer(ref)
+    end
+
+    %{state | timeout_ref: Process.send_after(self(), :timeout, timeout_ms())}
+  end
+
+  defp timeout_ms do
+    Application.fetch_env!(:slippi_chat, :chat_session_timeout_ms)
   end
 end

--- a/lib/slippi_chat/chat_sessions/chat_session.ex
+++ b/lib/slippi_chat/chat_sessions/chat_session.ex
@@ -52,7 +52,9 @@ defmodule SlippiChat.ChatSessions.ChatSession do
   @impl true
   def handle_call({:send_message, sender, content}, _from, state) do
     new_message = Message.new(sender, content)
-    {:reply, {:ok, new_message}, %{state | messages: [new_message | state.messages]} |> set_timeout(),
+
+    {:reply, {:ok, new_message},
+     %{state | messages: [new_message | state.messages]} |> set_timeout(),
      {:continue, {:notify_subscribers, [:session, :message], new_message}}}
   end
 

--- a/lib/slippi_chat/chat_sessions/chat_session.ex
+++ b/lib/slippi_chat/chat_sessions/chat_session.ex
@@ -7,6 +7,7 @@ defmodule SlippiChat.ChatSessions.ChatSession do
   require Logger
 
   alias SlippiChat.ChatSessions
+  alias SlippiChat.ChatSessions.Message
 
   # TODO: More session end conditions
   # - send event on slippi quit out, quit when last player disconnects
@@ -25,8 +26,8 @@ defmodule SlippiChat.ChatSessions.ChatSession do
     GenServer.call(server, :get_player_codes)
   end
 
-  def send_message(server, message) do
-    GenServer.call(server, {:send_message, message})
+  def send_message(server, sender, content) do
+    GenServer.call(server, {:send_message, sender, content})
   end
 
   def list_messages(server) do
@@ -49,7 +50,8 @@ defmodule SlippiChat.ChatSessions.ChatSession do
   end
 
   @impl true
-  def handle_call({:send_message, new_message}, _from, state) do
+  def handle_call({:send_message, sender, content}, _from, state) do
+    new_message = Message.new(sender, content)
     {:reply, {:ok, new_message}, %{state | messages: [new_message | state.messages]} |> set_timeout(),
      {:continue, {:notify_subscribers, [:session, :message], new_message}}}
   end

--- a/lib/slippi_chat/chat_sessions/message.ex
+++ b/lib/slippi_chat/chat_sessions/message.ex
@@ -6,19 +6,19 @@ defmodule SlippiChat.ChatSessions.Message do
   @type player_code :: String.t()
   @type t :: %__MODULE__{
           id: String.t(),
-          content: String.t(),
-          sender: player_code()
+          sender: player_code(),
+          content: String.t()
         }
 
-  defstruct [:id, :content, :sender]
+  defstruct [:id, :sender, :content]
 
-  def new(content, sender) do
-    %__MODULE__{id: Ecto.UUID.generate(), content: content, sender: sender}
+  def new(sender, content) do
+    %__MODULE__{id: Ecto.UUID.generate(), sender: sender, content: content}
   end
 end
 
 defimpl Jason.Encoder, for: SlippiChat.ChatSessions.Message do
-  def encode(%SlippiChat.ChatSessions.Message{id: id, content: content, sender: sender}, opts) do
-    Jason.Encode.map(%{id: id, content: content, sender: sender}, opts)
+  def encode(%SlippiChat.ChatSessions.Message{id: id, sender: sender, content: content}, opts) do
+    Jason.Encode.map(%{id: id, sender: sender, content: content}, opts)
   end
 end

--- a/lib/slippi_chat/chat_sessions/supervisor.ex
+++ b/lib/slippi_chat/chat_sessions/supervisor.ex
@@ -1,0 +1,17 @@
+defmodule SlippiChat.ChatSessions.Supervisor do
+  use Supervisor
+
+  def start_link(opts) do
+    Supervisor.start_link(__MODULE__, :ok, opts)
+  end
+
+  @impl true
+  def init(:ok) do
+    children = [
+      {SlippiChat.ChatSessionRegistry, name: SlippiChat.ChatSessionRegistry},
+      {DynamicSupervisor, name: SlippiChat.ChatSessionSupervisor, strategy: :one_for_one}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end

--- a/lib/slippi_chat_web/channels/client_channel.ex
+++ b/lib/slippi_chat_web/channels/client_channel.ex
@@ -1,4 +1,4 @@
-defmodule SlippiChat.ClientChannel do
+defmodule SlippiChatWeb.ClientChannel do
   use Phoenix.Channel
 
   alias SlippiChat.ChatSessionRegistry

--- a/lib/slippi_chat_web/channels/user_socket.ex
+++ b/lib/slippi_chat_web/channels/user_socket.ex
@@ -1,8 +1,8 @@
-defmodule SlippiChat.UserSocket do
+defmodule SlippiChatWeb.UserSocket do
   use Phoenix.Socket
 
   ## Channels
-  channel "clients", SlippiChat.ClientChannel
+  channel "clients", SlippiChatWeb.ClientChannel
 
   # Socket params are passed from the client and can
   # be used to verify and authenticate a user. After

--- a/lib/slippi_chat_web/channels/user_socket.ex
+++ b/lib/slippi_chat_web/channels/user_socket.ex
@@ -2,7 +2,7 @@ defmodule SlippiChat.UserSocket do
   use Phoenix.Socket
 
   ## Channels
-  channel "players:*", SlippiChat.PlayerChannel
+  channel "clients", SlippiChat.ClientChannel
 
   # Socket params are passed from the client and can
   # be used to verify and authenticate a user. After

--- a/lib/slippi_chat_web/endpoint.ex
+++ b/lib/slippi_chat_web/endpoint.ex
@@ -13,7 +13,7 @@ defmodule SlippiChatWeb.Endpoint do
 
   socket "/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]]
 
-  socket "/socket", SlippiChat.UserSocket,
+  socket "/socket", SlippiChatWeb.UserSocket,
     websocket: true,
     longpoll: false
 

--- a/lib/slippi_chat_web/live/chat_live/message/form.ex
+++ b/lib/slippi_chat_web/live/chat_live/message/form.ex
@@ -18,6 +18,7 @@ defmodule SlippiChatWeb.ChatLive.Message.Form do
     ~H"""
     <div>
       <.simple_form
+        id="message-form"
         for={@form}
         as={:message}
         phx-submit="save"

--- a/lib/slippi_chat_web/live/chat_live/message/form.ex
+++ b/lib/slippi_chat_web/live/chat_live/message/form.ex
@@ -3,7 +3,7 @@ defmodule SlippiChatWeb.ChatLive.Message.Form do
 
   import SlippiChatWeb.CoreComponents
 
-  alias SlippiChat.ChatSessions.{ChatSession, Message}
+  alias SlippiChat.ChatSessions.ChatSession
 
   def update(assigns, socket) do
     changeset = change_message(%{})
@@ -39,8 +39,7 @@ defmodule SlippiChatWeb.ChatLive.Message.Form do
   end
 
   def handle_event("save", %{"message" => %{"content" => content}}, socket) do
-    message = Message.new(content, socket.assigns.sender)
-    ChatSession.send_message(socket.assigns.chat_session_pid, message)
+    ChatSession.send_message(socket.assigns.chat_session_pid, socket.assigns.sender, content)
     empty_changeset = change_message(%{})
 
     {:noreply, socket |> assign_form(empty_changeset)}

--- a/lib/slippi_chat_web/live/chat_live/root.ex
+++ b/lib/slippi_chat_web/live/chat_live/root.ex
@@ -68,9 +68,9 @@ defmodule SlippiChatWeb.ChatLive.Root do
     end
 
     socket =
-      with {:ok, pid} when is_pid(pid) <- ChatSessionRegistry.lookup(chat_session_registry(), player_code),
-          player_codes when is_list(player_codes) <- ChatSession.get_player_codes(pid)
-      do
+      with {:ok, pid} when is_pid(pid) <-
+             ChatSessionRegistry.lookup(chat_session_registry(), player_code),
+           player_codes when is_list(player_codes) <- ChatSession.get_player_codes(pid) do
         messages = ChatSession.list_messages(pid)
         online_codes = online_players(player_codes)
         chat_session_topic = ChatSessions.chat_session_topic(player_codes)
@@ -141,7 +141,10 @@ defmodule SlippiChatWeb.ChatLive.Root do
   end
 
   # TODO: Create connect/disconnect events via handle_metas rather than fetching from presence here
-  def handle_info(%Phoenix.Socket.Broadcast{event: "presence_diff", topic: "clients", payload: _payload}, socket) do
+  def handle_info(
+        %Phoenix.Socket.Broadcast{event: "presence_diff", topic: "clients", payload: _payload},
+        socket
+      ) do
     if socket.assigns.chat_session_pid do
       {:noreply, socket |> assign(:online_codes, online_players(socket.assigns.player_codes))}
     else

--- a/lib/slippi_chat_web/live/chat_live/root.ex
+++ b/lib/slippi_chat_web/live/chat_live/root.ex
@@ -5,6 +5,10 @@ defmodule SlippiChatWeb.ChatLive.Root do
   alias SlippiChat.ChatSessions.ChatSession
   alias SlippiChatWeb.{Endpoint, Presence}
 
+  defp chat_session_registry do
+    Application.fetch_env!(:slippi_chat, :chat_session_registry)
+  end
+
   @impl true
   def render(assigns) do
     ~H"""
@@ -64,7 +68,7 @@ defmodule SlippiChatWeb.ChatLive.Root do
     end
 
     socket =
-      with {:ok, pid} when is_pid(pid) <- ChatSessionRegistry.lookup(ChatSessionRegistry, player_code),
+      with {:ok, pid} when is_pid(pid) <- ChatSessionRegistry.lookup(chat_session_registry(), player_code),
           player_codes when is_list(player_codes) <- ChatSession.get_player_codes(pid)
       do
         messages = ChatSession.list_messages(pid)

--- a/lib/slippi_chat_web/live/chat_live/root.ex
+++ b/lib/slippi_chat_web/live/chat_live/root.ex
@@ -2,7 +2,7 @@ defmodule SlippiChatWeb.ChatLive.Root do
   use SlippiChatWeb, :live_view
 
   alias SlippiChat.{ChatSessions, ChatSessionRegistry}
-  alias SlippiChat.ChatSessions.{ChatSession, Message}
+  alias SlippiChat.ChatSessions.ChatSession
   alias SlippiChatWeb.{Endpoint, Presence}
 
   @impl true
@@ -95,8 +95,7 @@ defmodule SlippiChatWeb.ChatLive.Root do
 
   @impl true
   def handle_event("send_message", %{"content" => content}, socket) do
-    message = Message.new(content, socket.assigns.player_code)
-    ChatSession.send_message(socket.assigns.chat_session_pid, message)
+    ChatSession.send_message(socket.assigns.chat_session_pid, socket.assigns.player_code, content)
     {:noreply, socket}
   end
 

--- a/lib/slippi_chat_web/live/chat_live/root.ex
+++ b/lib/slippi_chat_web/live/chat_live/root.ex
@@ -1,17 +1,31 @@
 defmodule SlippiChatWeb.ChatLive.Root do
   use SlippiChatWeb, :live_view
 
-  alias SlippiChat.ChatSessionRegistry
+  alias SlippiChat.{ChatSessions, ChatSessionRegistry}
   alias SlippiChat.ChatSessions.{ChatSession, Message}
+  alias SlippiChatWeb.{Endpoint, Presence}
 
   @impl true
   def render(assigns) do
     ~H"""
     <div class="mb-3">
-      <ul>
-        <li>User: <%= @player_code %></li>
-        <li>Chat session: <%= inspect(@players) %></li>
-      </ul>
+      <p>User: <%= @player_code %></p>
+      <%= if @chat_session_pid do %>
+        <div>
+          <p>Chat session players:</p>
+          <ul>
+            <%= for player_code <- @player_codes do %>
+              <%= if Enum.member?(@online_codes, player_code) do %>
+                <li class="online"><%= player_code %> (online)</li>
+              <% else %>
+                <li><%= player_code %></li>
+              <% end %>
+            <% end %>
+          </ul>
+        </div>
+      <% else %>
+        <div>No chat session in progress.</div>
+      <% end %>
 
       <%= if @chat_session_pid do %>
         <h3>Chat</h3>
@@ -41,32 +55,42 @@ defmodule SlippiChatWeb.ChatLive.Root do
   @impl true
   def mount(%{"code" => code}, _session, socket) do
     player_code = translate_code(code)
-
-    {pid, players} =
-      case ChatSessionRegistry.lookup(ChatSessionRegistry, player_code) do
-        :error -> {nil, nil}
-        {:ok, %{current_chat_session: nil}} -> {nil, nil}
-        {:ok, %{current_chat_session: session_data}} -> {session_data.pid, session_data.players}
-      end
+    socket = assign(socket, :player_code, player_code)
 
     if connected?(socket) do
-      # TODO: Module specifically for subscribe functions and notification helpers?
-      Phoenix.PubSub.subscribe(SlippiChat.PubSub, "chat_sessions:#{player_code}")
-
-      if pid do
-        {:ok, uuid} = ChatSession.get_uuid(pid)
-        Phoenix.PubSub.subscribe(SlippiChat.PubSub, "chat_sessions:#{uuid}")
-      end
+      player_topic = ChatSessions.player_topic(player_code)
+      Endpoint.subscribe(player_topic)
+      Endpoint.subscribe("clients")
     end
 
-    messages = if pid, do: ChatSession.list_messages(pid), else: []
+    socket =
+      with {:ok, pid} when is_pid(pid) <- ChatSessionRegistry.lookup(ChatSessionRegistry, player_code),
+          player_codes when is_list(player_codes) <- ChatSession.get_player_codes(pid)
+      do
+        messages = ChatSession.list_messages(pid)
+        online_codes = online_players(player_codes)
+        chat_session_topic = ChatSessions.chat_session_topic(player_codes)
 
-    {:ok,
-     socket
-     |> assign(:player_code, player_code)
-     |> assign(:chat_session_pid, pid)
-     |> assign(:players, players)
-     |> stream(:messages, messages)}
+        if connected?(socket) do
+          Endpoint.subscribe(chat_session_topic)
+        end
+
+        socket
+        |> assign(:chat_session_pid, pid)
+        |> assign(:player_codes, player_codes)
+        |> assign(:online_codes, online_codes)
+        |> assign(:session_topic, chat_session_topic)
+        |> stream(:messages, messages)
+      else
+        _ ->
+          socket
+          |> assign(:chat_session_pid, nil)
+          |> assign(:player_codes, nil)
+          |> assign(:online_codes, [])
+          |> stream(:messages, [])
+      end
+
+    {:ok, socket}
   end
 
   @impl true
@@ -86,25 +110,49 @@ defmodule SlippiChatWeb.ChatLive.Root do
   end
 
   @impl true
-  def handle_info({[:session, :start], {players, pid}}, socket) do
-    {:ok, uuid} = ChatSession.get_uuid(pid)
-    Phoenix.PubSub.subscribe(SlippiChat.PubSub, "chat_sessions:#{uuid}")
+  def handle_info({[:session, :start], {player_codes, pid}}, socket) do
+    topic = ChatSessions.chat_session_topic(player_codes)
+    Endpoint.subscribe(topic)
 
     {:noreply,
      socket
      |> assign(:chat_session_pid, pid)
-     |> assign(:players, players)}
+     |> assign(:player_codes, player_codes)
+     |> assign(:online_codes, online_players(player_codes))
+     |> assign(:session_topic, topic)}
   end
 
   def handle_info({[:session, :end], _result}, socket) do
+    Endpoint.unsubscribe(socket.assigns.session_topic)
+
     {:noreply,
      socket
      |> assign(:chat_session_pid, nil)
-     |> assign(:players, nil)}
+     |> assign(:player_codes, nil)
+     |> assign(:online_codes, [])
+     |> assign(:session_topic, nil)}
   end
 
   def handle_info({[:session, :message], new_message}, socket) do
     {:noreply, socket |> stream_insert(:messages, new_message)}
+  end
+
+  # TODO: Create connect/disconnect events via handle_metas rather than fetching from presence here
+  def handle_info(%Phoenix.Socket.Broadcast{event: "presence_diff", topic: "clients", payload: _payload}, socket) do
+    if socket.assigns.chat_session_pid do
+      {:noreply, socket |> assign(:online_codes, online_players(socket.assigns.player_codes))}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  defp online_players(player_codes) do
+    Enum.reduce(player_codes, [], fn player_code, acc ->
+      case Presence.get_by_key("clients", player_code) do
+        [] -> acc
+        _ -> [player_code | acc]
+      end
+    end)
   end
 
   defp translate_code(player_code) do

--- a/lib/slippi_chat_web/presence.ex
+++ b/lib/slippi_chat_web/presence.ex
@@ -1,0 +1,5 @@
+defmodule SlippiChatWeb.Presence do
+  use Phoenix.Presence,
+    otp_app: :slippi_chat,
+    pubsub_server: SlippiChat.PubSub
+end

--- a/test/slippi_chat/chat_session_registry_test.exs
+++ b/test/slippi_chat/chat_session_registry_test.exs
@@ -8,12 +8,17 @@ defmodule SlippiChat.ChatSessionRegistryTest do
 
   setup do
     {:ok, supervisor_pid} = DynamicSupervisor.start_link(strategy: :one_for_one)
-    pid = start_supervised!({ChatSessionRegistry, name: @registry_name, supervisor: supervisor_pid})
+
+    pid =
+      start_supervised!({ChatSessionRegistry, name: @registry_name, supervisor: supervisor_pid})
+
     %{pid: pid}
   end
 
   describe "start_chat_session/2" do
-    test "starts a chat session between the given players and broadcasts to player topics", %{pid: registry_pid} do
+    test "starts a chat session between the given players and broadcasts to player topics", %{
+      pid: registry_pid
+    } do
       Phoenix.PubSub.subscribe(SlippiChat.PubSub, ChatSessions.player_topic("ALIC#3"))
       Phoenix.PubSub.subscribe(SlippiChat.PubSub, ChatSessions.player_topic("BOB#1"))
       Phoenix.PubSub.subscribe(SlippiChat.PubSub, ChatSessions.player_topic("CARL#4"))
@@ -27,13 +32,20 @@ defmodule SlippiChat.ChatSessionRegistryTest do
     end
 
     test "doesn't start multiple sessions with the same players", %{pid: registry_pid} do
-      assert {:ok, _pid} = ChatSessionRegistry.start_chat_session(registry_pid, ["ALIC#2", "ALIC#3", "BOB#1"])
-      assert {:already_started, _pid} = ChatSessionRegistry.start_chat_session(registry_pid, ["BOB#1", "ALIC#2", "ALIC#3"])
+      assert {:ok, _pid} =
+               ChatSessionRegistry.start_chat_session(registry_pid, ["ALIC#2", "ALIC#3", "BOB#1"])
+
+      assert {:already_started, _pid} =
+               ChatSessionRegistry.start_chat_session(registry_pid, ["BOB#1", "ALIC#2", "ALIC#3"])
     end
 
     test "ends existing sessions with participating players", %{pid: registry_pid} do
-      {:ok, session1_pid} = ChatSessionRegistry.start_chat_session(registry_pid, ["ALIC#3", "BOB#1"])
-      {:ok, session2_pid} = ChatSessionRegistry.start_chat_session(registry_pid, ["CARL#4", "DAVE#7"])
+      {:ok, session1_pid} =
+        ChatSessionRegistry.start_chat_session(registry_pid, ["ALIC#3", "BOB#1"])
+
+      {:ok, session2_pid} =
+        ChatSessionRegistry.start_chat_session(registry_pid, ["CARL#4", "DAVE#7"])
+
       {:ok, session3_pid} = ChatSessionRegistry.start_chat_session(registry_pid, ["X#1", "Y#2"])
       Process.monitor(session1_pid)
       Process.monitor(session2_pid)
@@ -42,7 +54,8 @@ defmodule SlippiChat.ChatSessionRegistryTest do
       assert Process.alive?(session1_pid)
       assert Process.alive?(session2_pid)
 
-      {:ok, session4_pid} = ChatSessionRegistry.start_chat_session(registry_pid, ["ALIC#3", "DAVE#7"])
+      {:ok, session4_pid} =
+        ChatSessionRegistry.start_chat_session(registry_pid, ["ALIC#3", "DAVE#7"])
 
       assert Process.alive?(session4_pid)
       assert_receive {:DOWN, _ref, :process, ^session1_pid, :normal}
@@ -53,7 +66,8 @@ defmodule SlippiChat.ChatSessionRegistryTest do
 
   describe "lookup/2" do
     test "finds session pid for a player code", %{pid: registry_pid} do
-      {:ok, session_pid} = ChatSessionRegistry.start_chat_session(registry_pid, ["ALIC#3", "BOB#1"])
+      {:ok, session_pid} =
+        ChatSessionRegistry.start_chat_session(registry_pid, ["ALIC#3", "BOB#1"])
 
       assert ChatSessionRegistry.lookup(@registry_name, "ALIC#3") == {:ok, session_pid}
       assert ChatSessionRegistry.lookup(@registry_name, "BOB#1") == {:ok, session_pid}

--- a/test/slippi_chat/chat_session_registry_test.exs
+++ b/test/slippi_chat/chat_session_registry_test.exs
@@ -1,7 +1,8 @@
 defmodule SlippiChat.ChatSessionRegistryTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
-  alias SlippiChat.ChatSessionRegistry
+  alias SlippiChat.{ChatSessions, ChatSessionRegistry}
+  alias SlippiChat.ChatSessions.ChatSession
 
   @registry_name __MODULE__
 
@@ -10,226 +11,52 @@ defmodule SlippiChat.ChatSessionRegistryTest do
     %{pid: pid}
   end
 
-  describe "register_client/2" do
-    test "adds a player code to the registry" do
-      :error = ChatSessionRegistry.lookup(@registry_name, "ALIC#3")
+  describe "start_chat_session/2" do
+    test "starts a chat session between the given players and broadcasts to player topics", %{pid: registry_pid} do
+      Phoenix.PubSub.subscribe(SlippiChat.PubSub, ChatSessions.player_topic("ALIC#3"))
+      Phoenix.PubSub.subscribe(SlippiChat.PubSub, ChatSessions.player_topic("BOB#1"))
+      Phoenix.PubSub.subscribe(SlippiChat.PubSub, ChatSessions.player_topic("CARL#4"))
 
-      :ok = ChatSessionRegistry.register_client(@registry_name, "ALIC#3")
-      {:ok, data} = ChatSessionRegistry.lookup(@registry_name, "ALIC#3")
-      assert data == %{current_game: nil, current_chat_session: nil}
+      player_codes = ["ALIC#3", "BOB#1"]
+      {:ok, session_pid} = ChatSessionRegistry.start_chat_session(registry_pid, player_codes)
 
-      :ok = ChatSessionRegistry.register_client(@registry_name, "ALIC#3")
-      {:ok, data} = ChatSessionRegistry.lookup(@registry_name, "ALIC#3")
-      assert data == %{current_game: nil, current_chat_session: nil}
+      assert ChatSession.get_player_codes(session_pid) == player_codes
+      assert_receive {[:session, :start], {^player_codes, pid}}
+      assert_receive {[:session, :start], {^player_codes, pid}}
+    end
+
+    test "doesn't start multiple sessions with the same players", %{pid: registry_pid} do
+      assert {:ok, _pid} = ChatSessionRegistry.start_chat_session(registry_pid, ["ALIC#2", "ALIC#3", "BOB#1"])
+      assert {:already_started, _pid} = ChatSessionRegistry.start_chat_session(registry_pid, ["BOB#1", "ALIC#2", "ALIC#3"])
+    end
+
+    test "ends existing sessions with participating players", %{pid: registry_pid} do
+      {:ok, session1_pid} = ChatSessionRegistry.start_chat_session(registry_pid, ["ALIC#3", "BOB#1"])
+      {:ok, session2_pid} = ChatSessionRegistry.start_chat_session(registry_pid, ["CARL#4", "DAVE#7"])
+      {:ok, session3_pid} = ChatSessionRegistry.start_chat_session(registry_pid, ["X#1", "Y#2"])
+      Process.monitor(session1_pid)
+      Process.monitor(session2_pid)
+      Process.monitor(session3_pid)
+
+      assert Process.alive?(session1_pid)
+      assert Process.alive?(session2_pid)
+
+      {:ok, session4_pid} = ChatSessionRegistry.start_chat_session(registry_pid, ["ALIC#3", "DAVE#7"])
+
+      assert Process.alive?(session4_pid)
+      assert_receive {:DOWN, _ref, :process, ^session1_pid, :normal}
+      assert_receive {:DOWN, _ref, :process, ^session2_pid, :normal}
+      refute_receive {:DOWN, _ref, :process, ^session3_pid, :normal}
     end
   end
 
-  describe "remove_client/2" do
-    test "removes a player code from the registry" do
-      ChatSessionRegistry.register_client(@registry_name, "ALIC#3")
-      {:ok, _data} = ChatSessionRegistry.lookup(@registry_name, "ALIC#3")
+  describe "lookup/2" do
+    test "finds session pid for a player code", %{pid: registry_pid} do
+      {:ok, session_pid} = ChatSessionRegistry.start_chat_session(registry_pid, ["ALIC#3", "BOB#1"])
 
-      :ok = ChatSessionRegistry.remove_client(@registry_name, "ALIC#3")
-      :error = ChatSessionRegistry.lookup(@registry_name, "ALIC#3")
-
-      :ok = ChatSessionRegistry.remove_client(@registry_name, "ALIC#3")
-      :error = ChatSessionRegistry.lookup(@registry_name, "ALIC#3")
-    end
-
-    test "stops an active session for removed client" do
-      ChatSessionRegistry.register_client(@registry_name, "ALIC#3")
-      ChatSessionRegistry.register_client(@registry_name, "BOB#1")
-
-      Phoenix.PubSub.subscribe(SlippiChat.PubSub, "chat_sessions:ALIC#3")
-
-      :ok = ChatSessionRegistry.game_started(@registry_name, "ALIC#3", ["ALIC#3", "BOB#1"])
-      {:ok, pid} = ChatSessionRegistry.game_started(@registry_name, "BOB#1", ["ALIC#3", "BOB#1"])
-
-      assert_receive {[:session, :start], {["ALIC#3", "BOB#1"], ^pid}}
-
-      ChatSessionRegistry.remove_client(@registry_name, "BOB#1")
-
-      assert_receive {[:session, :end], {["ALIC#3", "BOB#1"], ^pid}}
-    end
-  end
-
-  describe "game_started/3" do
-    test "starts a game in the registry" do
-      ChatSessionRegistry.register_client(@registry_name, "ALIC#3")
-      {:ok, %{current_game: nil}} = ChatSessionRegistry.lookup(@registry_name, "ALIC#3")
-
-      :ok = ChatSessionRegistry.game_started(@registry_name, "ALIC#3", ["ALIC#3", "BOB#1"])
-
-      {:ok, %{current_game: ["ALIC#3", "BOB#1"], current_chat_session: nil}} =
-        ChatSessionRegistry.lookup(@registry_name, "ALIC#3")
-    end
-
-    test "only affects current_game for the specified client" do
-      ChatSessionRegistry.register_client(@registry_name, "ALIC#3")
-      ChatSessionRegistry.register_client(@registry_name, "BOB#1")
-
-      :ok = ChatSessionRegistry.game_started(@registry_name, "ALIC#3", ["ALIC#3", "BOB#1"])
-
-      {:ok, %{current_game: nil, current_chat_session: nil}} =
-        ChatSessionRegistry.lookup(@registry_name, "BOB#1")
-    end
-
-    test "starts a session when all players are in the same game" do
-      ChatSessionRegistry.register_client(@registry_name, "ALIC#3")
-      ChatSessionRegistry.register_client(@registry_name, "BOB#1")
-      ChatSessionRegistry.register_client(@registry_name, "CAT#2")
-      ChatSessionRegistry.register_client(@registry_name, "DAVE#4")
-
-      Phoenix.PubSub.subscribe(SlippiChat.PubSub, "chat_sessions:ALIC#3")
-
-      :ok =
-        ChatSessionRegistry.game_started(@registry_name, "ALIC#3", [
-          "ALIC#3",
-          "BOB#1",
-          "CAT#2",
-          "DAVE#4"
-        ])
-
-      :ok =
-        ChatSessionRegistry.game_started(@registry_name, "BOB#1", [
-          "ALIC#3",
-          "BOB#1",
-          "CAT#2",
-          "DAVE#4"
-        ])
-
-      :ok =
-        ChatSessionRegistry.game_started(@registry_name, "CAT#2", [
-          "ALIC#3",
-          "BOB#1",
-          "CAT#2",
-          "DAVE#4"
-        ])
-
-      {:ok, pid} =
-        ChatSessionRegistry.game_started(@registry_name, "DAVE#4", [
-          "ALIC#3",
-          "BOB#1",
-          "CAT#2",
-          "DAVE#4"
-        ])
-
-      assert_receive {[:session, :start], {["ALIC#3", "BOB#1", "CAT#2", "DAVE#4"], ^pid}}
-
-      assert_player_data = fn player_code ->
-        {:ok, data} = ChatSessionRegistry.lookup(@registry_name, player_code)
-        assert data.current_game == ["ALIC#3", "BOB#1", "CAT#2", "DAVE#4"]
-        assert data.current_chat_session.players == ["ALIC#3", "BOB#1", "CAT#2", "DAVE#4"]
-      end
-
-      Enum.each(["ALIC#3", "BOB#1", "CAT#2", "DAVE#4"], assert_player_data)
-    end
-
-    test "stops old sessions when a new session starts, case 1" do
-      ChatSessionRegistry.register_client(@registry_name, "ALIC#3")
-      ChatSessionRegistry.register_client(@registry_name, "BOB#1")
-      ChatSessionRegistry.register_client(@registry_name, "CAT#2")
-      ChatSessionRegistry.register_client(@registry_name, "DAVE#4")
-      ChatSessionRegistry.register_client(@registry_name, "EVE#5")
-
-      Phoenix.PubSub.subscribe(SlippiChat.PubSub, "chat_sessions:ALIC#3")
-      Phoenix.PubSub.subscribe(SlippiChat.PubSub, "chat_sessions:CAT#2")
-
-      # Session between ALIC#3 and BOB#1
-      :ok = ChatSessionRegistry.game_started(@registry_name, "ALIC#3", ["ALIC#3", "BOB#1"])
-      {:ok, pid1} = ChatSessionRegistry.game_started(@registry_name, "BOB#1", ["ALIC#3", "BOB#1"])
-
-      # Session between CAT#2 and DAVE#4
-      :ok = ChatSessionRegistry.game_started(@registry_name, "CAT#2", ["CAT#2", "DAVE#4"])
-
-      {:ok, pid2} =
-        ChatSessionRegistry.game_started(@registry_name, "DAVE#4", ["CAT#2", "DAVE#4"])
-
-      # Game start between EVE#5, ALIC#3, and CAT#2
-      :ok =
-        ChatSessionRegistry.game_started(@registry_name, "EVE#5", ["ALIC#3", "CAT#2", "EVE#5"])
-
-      # Old sessions for ALIC#3 and CAT#2 are stopped
-      assert_receive {[:session, :end], {["ALIC#3", "BOB#1"], ^pid1}}
-
-      {:ok, %{current_game: ["ALIC#3", "BOB#1"], current_chat_session: nil}} =
-        ChatSessionRegistry.lookup(@registry_name, "ALIC#3")
-
-      assert_receive {[:session, :end], {["CAT#2", "DAVE#4"], ^pid2}}
-
-      {:ok, %{current_game: ["CAT#2", "DAVE#4"], current_chat_session: nil}} =
-        ChatSessionRegistry.lookup(@registry_name, "CAT#2")
-
-      refute Process.alive?(pid1)
-      refute Process.alive?(pid2)
-    end
-
-    test "stops old sessions when a new session starts, case 2" do
-      ChatSessionRegistry.register_client(@registry_name, "ALIC#3")
-      ChatSessionRegistry.register_client(@registry_name, "BOB#1")
-      ChatSessionRegistry.register_client(@registry_name, "EVE#5")
-
-      Phoenix.PubSub.subscribe(SlippiChat.PubSub, "chat_sessions:ALIC#3")
-
-      # Session between ALIC#3 and BOB#1
-      :ok = ChatSessionRegistry.game_started(@registry_name, "ALIC#3", ["ALIC#3", "BOB#1"])
-      {:ok, pid} = ChatSessionRegistry.game_started(@registry_name, "BOB#1", ["ALIC#3", "BOB#1"])
-
-      # Game start between EVE#5, ALIC#3, and BOB#1
-      :ok =
-        ChatSessionRegistry.game_started(@registry_name, "EVE#5", ["ALIC#3", "BOB#1", "EVE#5"])
-
-      # Old session for ALIC#3 and BOB#1 is stopped
-      assert_receive {[:session, :end], {["ALIC#3", "BOB#1"], ^pid}}
-
-      {:ok, %{current_game: ["ALIC#3", "BOB#1"], current_chat_session: nil}} =
-        ChatSessionRegistry.lookup(@registry_name, "ALIC#3")
-
-      refute Process.alive?(pid)
-    end
-  end
-
-  describe "game_ended/2" do
-    test "updates a client's current game in the registry" do
-      ChatSessionRegistry.register_client(@registry_name, "ALIC#3")
-
-      :ok = ChatSessionRegistry.game_started(@registry_name, "ALIC#3", ["ALIC#3", "BOB#1"])
-
-      {:ok, %{current_game: ["ALIC#3", "BOB#1"]}} =
-        ChatSessionRegistry.lookup(@registry_name, "ALIC#3")
-
-      :ok = ChatSessionRegistry.game_ended(@registry_name, "ALIC#3")
-      {:ok, %{current_game: nil}} = ChatSessionRegistry.lookup(@registry_name, "ALIC#3")
-    end
-
-    test "only affects current_game for the specified client" do
-      ChatSessionRegistry.register_client(@registry_name, "ALIC#3")
-      ChatSessionRegistry.register_client(@registry_name, "BOB#1")
-
-      :ok = ChatSessionRegistry.game_started(@registry_name, "ALIC#3", ["ALIC#3", "BOB#1"])
-      {:ok, pid} = ChatSessionRegistry.game_started(@registry_name, "BOB#1", ["ALIC#3", "BOB#1"])
-      :ok = ChatSessionRegistry.game_ended(@registry_name, "ALIC#3")
-
-      {:ok, %{current_game: ["ALIC#3", "BOB#1"], current_chat_session: %{pid: ^pid}}} =
-        ChatSessionRegistry.lookup(@registry_name, "BOB#1")
-    end
-  end
-
-  describe "event handlers" do
-    test "removes client sessions when session process terminates" do
-      ChatSessionRegistry.register_client(@registry_name, "ALIC#3")
-      ChatSessionRegistry.register_client(@registry_name, "BOB#1")
-
-      :ok = ChatSessionRegistry.game_started(@registry_name, "ALIC#3", ["ALIC#3", "BOB#1"])
-      {:ok, pid} = ChatSessionRegistry.game_started(@registry_name, "BOB#1", ["ALIC#3", "BOB#1"])
-
-      Phoenix.PubSub.subscribe(SlippiChat.PubSub, "chat_sessions:BOB#1")
-      GenServer.stop(pid)
-
-      assert_receive {[:session, :end], {["ALIC#3", "BOB#1"], ^pid}}
-
-      {:ok, %{current_chat_session: nil}} = ChatSessionRegistry.lookup(@registry_name, "ALIC#3")
-      {:ok, %{current_chat_session: nil}} = ChatSessionRegistry.lookup(@registry_name, "BOB#1")
+      assert ChatSessionRegistry.lookup(@registry_name, "ALIC#3") == {:ok, session_pid}
+      assert ChatSessionRegistry.lookup(@registry_name, "BOB#1") == {:ok, session_pid}
+      assert ChatSessionRegistry.lookup(@registry_name, "CARL#4") == :error
     end
   end
 end

--- a/test/slippi_chat/chat_session_registry_test.exs
+++ b/test/slippi_chat/chat_session_registry_test.exs
@@ -7,7 +7,8 @@ defmodule SlippiChat.ChatSessionRegistryTest do
   @registry_name __MODULE__
 
   setup do
-    pid = start_supervised!({ChatSessionRegistry, name: @registry_name})
+    {:ok, supervisor_pid} = DynamicSupervisor.start_link(strategy: :one_for_one)
+    pid = start_supervised!({ChatSessionRegistry, name: @registry_name, supervisor: supervisor_pid})
     %{pid: pid}
   end
 
@@ -21,8 +22,8 @@ defmodule SlippiChat.ChatSessionRegistryTest do
       {:ok, session_pid} = ChatSessionRegistry.start_chat_session(registry_pid, player_codes)
 
       assert ChatSession.get_player_codes(session_pid) == player_codes
-      assert_receive {[:session, :start], {^player_codes, pid}}
-      assert_receive {[:session, :start], {^player_codes, pid}}
+      assert_receive {[:session, :start], {^player_codes, ^session_pid}}
+      assert_receive {[:session, :start], {^player_codes, ^session_pid}}
     end
 
     test "doesn't start multiple sessions with the same players", %{pid: registry_pid} do

--- a/test/slippi_chat/chat_sessions/chat_session_test.exs
+++ b/test/slippi_chat/chat_sessions/chat_session_test.exs
@@ -2,7 +2,7 @@ defmodule SlippiChat.ChatSessionTest do
   use ExUnit.Case, async: true
 
   alias SlippiChat.ChatSessions
-  alias SlippiChat.ChatSessions.{ChatSession, Message}
+  alias SlippiChat.ChatSessions.ChatSession
 
   defp chat_session_timeout_ms do
     Application.fetch_env!(:slippi_chat, :chat_session_timeout_ms)
@@ -25,17 +25,11 @@ defmodule SlippiChat.ChatSessionTest do
     test "lists all messages of the chat session", %{pid: pid} do
       assert ChatSession.list_messages(pid) == []
 
-      msg1 = Message.new("message1", "ALIC#3")
-      msg2 = Message.new("message2", "BOB#1")
-      msg3 = Message.new("message3", "ALIC#3")
-      msg4 = Message.new("message4", "TEST#123")
-      msg5 = Message.new("message5", "TEST#123")
-
-      ChatSession.send_message(pid, msg1)
-      ChatSession.send_message(pid, msg2)
-      ChatSession.send_message(pid, msg3)
-      ChatSession.send_message(pid, msg4)
-      ChatSession.send_message(pid, msg5)
+      {:ok, msg1} = ChatSession.send_message(pid, "ALIC#3", "message1")
+      {:ok, msg2} = ChatSession.send_message(pid, "BOB#1", "message2")
+      {:ok, msg3} = ChatSession.send_message(pid, "ALIC#3", "message3")
+      {:ok, msg4} = ChatSession.send_message(pid, "TEST#123", "message4")
+      {:ok, msg5} = ChatSession.send_message(pid, "TEST#123", "message5")
 
       assert ChatSession.list_messages(pid) == [msg5, msg4, msg3, msg2, msg1]
     end
@@ -48,11 +42,9 @@ defmodule SlippiChat.ChatSessionTest do
 
       assert ChatSession.list_messages(pid) == []
 
-      message = Message.new("test message", "ALIC#3")
-      ChatSession.send_message(pid, message)
+      {:ok, message} = ChatSession.send_message(pid, "ALIC#3", "test message")
 
       assert ChatSession.list_messages(pid) == [message]
-
       assert_receive {[:session, :message], ^message}
     end
   end

--- a/test/slippi_chat/chat_sessions/chat_session_test.exs
+++ b/test/slippi_chat/chat_sessions/chat_session_test.exs
@@ -1,5 +1,5 @@
 defmodule SlippiChat.ChatSessionTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias SlippiChat.ChatSessions
   alias SlippiChat.ChatSessions.ChatSession

--- a/test/slippi_chat/chat_sessions_test.exs
+++ b/test/slippi_chat/chat_sessions_test.exs
@@ -12,8 +12,11 @@ defmodule SlippiChat.ChatSessionsTest do
 
   describe "chat_session_topic/1" do
     test "returns the pubsub topic for a list of players" do
-      assert ChatSessions.chat_session_topic(["DAN#432", "BILL#747"]) == "chat_sessions:BILL#747,DAN#432"
-      assert ChatSessions.chat_session_topic(["X#732", "bob#421", "x#123"]) == "chat_sessions:BOB#421,X#123,X#732"
+      assert ChatSessions.chat_session_topic(["DAN#432", "BILL#747"]) ==
+               "chat_sessions:BILL#747,DAN#432"
+
+      assert ChatSessions.chat_session_topic(["X#732", "bob#421", "x#123"]) ==
+               "chat_sessions:BOB#421,X#123,X#732"
     end
   end
 end

--- a/test/slippi_chat/chat_sessions_test.exs
+++ b/test/slippi_chat/chat_sessions_test.exs
@@ -1,0 +1,19 @@
+defmodule SlippiChat.ChatSessionsTest do
+  use ExUnit.Case, async: true
+
+  alias SlippiChat.ChatSessions
+
+  describe "player_topic/1" do
+    test "returns the pubsub topic for a specific player" do
+      assert ChatSessions.player_topic("TEST#1") == "chat_sessions:TEST#1"
+      assert ChatSessions.player_topic("lower#5") == "chat_sessions:LOWER#5"
+    end
+  end
+
+  describe "chat_session_topic/1" do
+    test "returns the pubsub topic for a list of players" do
+      assert ChatSessions.chat_session_topic(["DAN#432", "BILL#747"]) == "chat_sessions:BILL#747,DAN#432"
+      assert ChatSessions.chat_session_topic(["X#732", "bob#421", "x#123"]) == "chat_sessions:BOB#421,X#123,X#732"
+    end
+  end
+end

--- a/test/slippi_chat_web/channels/client_channel_test.exs
+++ b/test/slippi_chat_web/channels/client_channel_test.exs
@@ -1,5 +1,5 @@
 defmodule SlippiChatWeb.ClientChannelTest do
-  use SlippiChatWeb.ChannelCase
+  use SlippiChatWeb.ChannelCase, async: false
 
   alias SlippiChat.ChatSessionRegistry
   alias SlippiChat.ChatSessions.{ChatSession, Message}
@@ -10,6 +10,12 @@ defmodule SlippiChatWeb.ClientChannelTest do
   end
 
   setup do
+    # Setup registry
+    {:ok, supervisor_pid} = DynamicSupervisor.start_link(strategy: :one_for_one)
+    registry_name = TestRegistry
+    start_supervised!({ChatSessionRegistry, name: registry_name, supervisor: supervisor_pid})
+    Application.put_env(:slippi_chat, :chat_session_registry, TestRegistry)
+
     # TODO: Authorize socket on connection rather than channel join
     client_code = "ABC#123"
 
@@ -18,7 +24,7 @@ defmodule SlippiChatWeb.ClientChannelTest do
       |> socket()
       |> subscribe_and_join(ClientChannel, "clients", %{"client_code" => client_code})
 
-    %{client_code: client_code, socket: socket}
+    %{client_code: client_code, socket: socket, registry_name: registry_name}
   end
 
   describe "join" do
@@ -40,14 +46,14 @@ defmodule SlippiChatWeb.ClientChannelTest do
   end
 
   describe "game_started event" do
-    test "starts a chat session", %{socket: socket, client_code: client_code} do
-      assert ChatSessionRegistry.lookup(ChatSessionRegistry, client_code) == :error
+    test "starts a chat session", %{socket: socket, client_code: client_code, registry_name: registry_name} do
+      assert ChatSessionRegistry.lookup(registry_name, client_code) == :error
 
       player_codes = [client_code, "XYZ#999"]
       push(socket, "game_started", %{"players" => player_codes})
 
       assert_push "session_start", ^player_codes
-      assert {:ok, _pid} = ChatSessionRegistry.lookup(ChatSessionRegistry, client_code)
+      assert {:ok, _pid} = ChatSessionRegistry.lookup(registry_name, client_code)
     end
   end
 
@@ -61,13 +67,13 @@ defmodule SlippiChatWeb.ClientChannelTest do
       assert_push "session_end", ^player_codes
     end
 
-    test "on chat session message, pushes to socket", %{socket: socket, client_code: client_code}  do
+    test "on chat session message, pushes to socket", %{socket: socket, client_code: client_code, registry_name: registry_name}  do
       player_codes = [client_code, "XYZ#999"]
 
       push(socket, "game_started", %{"players" => player_codes})
       assert_push "session_start", ^player_codes
 
-      {:ok, pid} = ChatSessionRegistry.lookup(ChatSessionRegistry, client_code)
+      {:ok, pid} = ChatSessionRegistry.lookup(registry_name, client_code)
       ChatSession.send_message(pid, client_code, "test message")
       assert_push "session_message", %Message{content: "test message", sender: ^client_code}
     end

--- a/test/slippi_chat_web/channels/client_channel_test.exs
+++ b/test/slippi_chat_web/channels/client_channel_test.exs
@@ -56,7 +56,7 @@ defmodule SlippiChatWeb.ClientChannelTest do
   end
 
   describe "PubSub messages" do
-    test "on session end, pushes to channel", %{socket: socket, client_code: client_code}  do
+    test "on session end, pushes to channel", %{socket: socket, client_code: client_code} do
       player_codes = [client_code, "XYZ#999"]
       push(socket, "game_started", %{"players" => player_codes})
 
@@ -65,7 +65,7 @@ defmodule SlippiChatWeb.ClientChannelTest do
       assert_push "session_end", ^player_codes
     end
 
-    test "on chat session message, pushes to socket", %{socket: socket, client_code: client_code}  do
+    test "on chat session message, pushes to socket", %{socket: socket, client_code: client_code} do
       player_codes = [client_code, "XYZ#999"]
 
       push(socket, "game_started", %{"players" => player_codes})

--- a/test/slippi_chat_web/channels/client_channel_test.exs
+++ b/test/slippi_chat_web/channels/client_channel_test.exs
@@ -68,7 +68,7 @@ defmodule SlippiChatWeb.ClientChannelTest do
       assert_push "session_start", ^player_codes
 
       {:ok, pid} = ChatSessionRegistry.lookup(ChatSessionRegistry, client_code)
-      ChatSession.send_message(pid, Message.new("test message", client_code))
+      ChatSession.send_message(pid, client_code, "test message")
       assert_push "session_message", %Message{content: "test message", sender: ^client_code}
     end
   end

--- a/test/slippi_chat_web/channels/client_channel_test.exs
+++ b/test/slippi_chat_web/channels/client_channel_test.exs
@@ -1,0 +1,75 @@
+defmodule SlippiChatWeb.ClientChannelTest do
+  use SlippiChatWeb.ChannelCase
+
+  alias SlippiChat.ChatSessionRegistry
+  alias SlippiChat.ChatSessions.{ChatSession, Message}
+  alias SlippiChatWeb.{Presence, UserSocket, ClientChannel}
+
+  defp chat_session_timeout_ms do
+    Application.fetch_env!(:slippi_chat, :chat_session_timeout_ms)
+  end
+
+  setup do
+    # TODO: Authorize socket on connection rather than channel join
+    client_code = "ABC#123"
+
+    {:ok, _reply, socket} =
+      UserSocket
+      |> socket()
+      |> subscribe_and_join(ClientChannel, "clients", %{"client_code" => client_code})
+
+    %{client_code: client_code, socket: socket}
+  end
+
+  describe "join" do
+    test "tracks via Presence", %{socket: socket1} do
+      assert Presence.list("clients") |> Map.keys() == ["ABC#123"]
+
+      {:ok, _reply, _socket2} =
+        UserSocket
+        |> socket()
+        |> subscribe_and_join(ClientChannel, "clients", %{"client_code" => "DEF#456"})
+
+      assert Presence.list("clients") |> Map.keys() == ["ABC#123", "DEF#456"]
+
+      Process.unlink(socket1.channel_pid)
+      :ok = close(socket1)
+
+      assert Presence.list("clients") |> Map.keys() == ["DEF#456"]
+    end
+  end
+
+  describe "game_started event" do
+    test "starts a chat session", %{socket: socket, client_code: client_code} do
+      assert ChatSessionRegistry.lookup(ChatSessionRegistry, client_code) == :error
+
+      player_codes = [client_code, "XYZ#999"]
+      push(socket, "game_started", %{"players" => player_codes})
+
+      assert_push "session_start", ^player_codes
+      assert {:ok, _pid} = ChatSessionRegistry.lookup(ChatSessionRegistry, client_code)
+    end
+  end
+
+  describe "PubSub messages" do
+    test "on session end, pushes to channel", %{socket: socket, client_code: client_code}  do
+      player_codes = [client_code, "XYZ#999"]
+      push(socket, "game_started", %{"players" => player_codes})
+
+      assert_push "session_start", ^player_codes
+      Process.sleep(chat_session_timeout_ms() + 50)
+      assert_push "session_end", ^player_codes
+    end
+
+    test "on chat session message, pushes to socket", %{socket: socket, client_code: client_code}  do
+      player_codes = [client_code, "XYZ#999"]
+
+      push(socket, "game_started", %{"players" => player_codes})
+      assert_push "session_start", ^player_codes
+
+      {:ok, pid} = ChatSessionRegistry.lookup(ChatSessionRegistry, client_code)
+      ChatSession.send_message(pid, Message.new("test message", client_code))
+      assert_push "session_message", %Message{content: "test message", sender: ^client_code}
+    end
+  end
+end

--- a/test/slippi_chat_web/live/game_live/root_test.ex
+++ b/test/slippi_chat_web/live/game_live/root_test.ex
@@ -1,0 +1,134 @@
+defmodule SlippiChatWeb.GameLive.RootTest do
+  use SlippiChatWeb.ConnCase, async: false
+  # TODO: Inject ChatSessionRegistry name to LV, use one named
+  #        after the test file, and async true
+
+  import Phoenix.LiveViewTest
+  import Phoenix.ChannelTest
+
+  alias SlippiChatWeb.Endpoint
+  alias SlippiChat.ChatSessionRegistry
+  alias SlippiChat.ChatSessions.ChatSession
+  alias SlippiChatWeb.ClientChannel
+
+  defp chat_session_timeout_ms do
+    Application.fetch_env!(:slippi_chat, :chat_session_timeout_ms)
+  end
+
+  describe "Show" do
+    ## Rendering
+
+    test "renders empty state when there is no chat session", %{conn: conn} do
+      {:ok, _lv, html} = live(conn, ~p"/chat/abc-123")
+
+      assert html =~ "ABC#123"
+      assert html =~ "No chat session in progress."
+    end
+
+    test "renders chat session and its data when one exists", %{conn: conn} do
+      player_codes = ["ABC#123", "XYZ#987"]
+      {:ok, pid} = ChatSessionRegistry.start_chat_session(ChatSessionRegistry, player_codes)
+      {:ok, message} = ChatSession.send_message(pid, "XYZ#987", "hello world!")
+      {:ok, _lv, html} = live(conn, ~p"/chat/abc-123")
+
+      assert html =~ "Chat session players:"
+      Enum.each(player_codes, fn player_code -> assert html =~ player_code end)
+      assert html =~ message.id
+      assert html =~ "hello world!"
+    end
+
+    ## Events
+
+    test "sends messages", %{conn: conn1} do
+      player_codes = ["ABC#123", "XYZ#987"]
+      ChatSessionRegistry.start_chat_session(ChatSessionRegistry, player_codes)
+
+      conn2 = Phoenix.ConnTest.build_conn()
+      {:ok, lv1, _html1} = live(conn1, ~p"/chat/abc-123")
+      {:ok, lv2, _html2} = live(conn2, ~p"/chat/xyz-987")
+
+      lv1
+      |> element("#message-form")
+      |> render_submit(%{message: %{content: "test message"}})
+
+      assert render(lv1) =~ "test message"
+      assert render(lv2) =~ "test message"
+    end
+
+    test "sending message resets room timeout", %{conn: conn} do
+      player_codes = ["ABC#123", "XYZ#987"]
+
+      # No refresh
+
+      {:ok, _pid} = ChatSessionRegistry.start_chat_session(ChatSessionRegistry, player_codes)
+      {:ok, lv, html} = live(conn, ~p"/chat/abc-123")
+      assert html =~ "Chat session players:"
+      Process.sleep(chat_session_timeout_ms())
+      refute render(lv) =~ "Chat session players:"
+
+      # Refresh
+
+      {:ok, _pid} = ChatSessionRegistry.start_chat_session(ChatSessionRegistry, player_codes)
+      {:ok, lv, html} = live(conn, ~p"/chat/abc-123")
+      assert html =~ "Chat session players:"
+      Process.sleep(div(chat_session_timeout_ms(), 2))
+
+      lv
+      |> element("#message-form")
+      |> render_submit(%{message: %{content: "test message"}})
+
+      Process.sleep(div(chat_session_timeout_ms(), 2))
+      assert render(lv) =~ "Chat session players:"
+      Process.sleep(chat_session_timeout_ms())
+      refute render(lv) =~ "Chat session players:"
+    end
+
+    test "displays online status of client for each player code", %{conn: conn1} do
+      player_codes = ["ABC#123", "XYZ#987"]
+      ChatSessionRegistry.start_chat_session(ChatSessionRegistry, player_codes)
+      Endpoint.subscribe("clients")
+
+      conn2 = Phoenix.ConnTest.build_conn()
+      {:ok, lv1, html1} = live(conn1, ~p"/chat/abc-123")
+      {:ok, lv2, html2} = live(conn2, ~p"/chat/xyz-987")
+
+      Enum.each([html1, html2], fn html ->
+        refute html =~ "ABC#123 (online)"
+        refute html =~ "XYZ#987 (online)"
+      end)
+
+      {:ok, _reply, socket_abc} =
+        UserSocket
+        |> socket()
+        |> subscribe_and_join(ClientChannel, "clients", %{"client_code" => "ABC#123"})
+
+      assert_broadcast "presence_diff", %{joins: %{"ABC#123" => _}}
+
+      Enum.each([render(lv1), render(lv2)], fn html ->
+        assert html =~ "ABC#123 (online)"
+        refute html =~ "XYZ#987 (online)"
+      end)
+
+      {:ok, _reply, _socket_xyz} =
+        UserSocket
+        |> socket()
+        |> subscribe_and_join(ClientChannel, "clients", %{"client_code" => "XYZ#987"})
+
+      assert_broadcast "presence_diff", %{joins: %{"XYZ#987" => _}}
+
+      Enum.each([render(lv1), render(lv2)], fn html ->
+        assert html =~ "ABC#123 (online)"
+        assert html =~ "XYZ#987 (online)"
+      end)
+
+      Process.unlink(socket_abc.channel_pid)
+      close(socket_abc)
+      assert_broadcast "presence_diff", %{leaves: %{"ABC#123" => _}}
+
+      Enum.each([render(lv1), render(lv2)], fn html ->
+        refute html =~ "ABC#123 (online)"
+        assert html =~ "XYZ#987 (online)"
+      end)
+    end
+  end
+end

--- a/test/slippi_chat_web/live/game_live/root_test.exs
+++ b/test/slippi_chat_web/live/game_live/root_test.exs
@@ -1,7 +1,5 @@
 defmodule SlippiChatWeb.GameLive.RootTest do
-  use SlippiChatWeb.ConnCase, async: false
-  # TODO: Inject ChatSessionRegistry name to LV, use one named
-  #        after the test file, and async true
+  use SlippiChatWeb.ConnCase, async: true
 
   import Phoenix.LiveViewTest
   import Phoenix.ChannelTest
@@ -17,16 +15,6 @@ defmodule SlippiChatWeb.GameLive.RootTest do
 
   defp chat_session_registry do
     Application.fetch_env!(:slippi_chat, :chat_session_registry)
-  end
-
-  setup do
-    # Setup registry
-    {:ok, supervisor_pid} = DynamicSupervisor.start_link(strategy: :one_for_one)
-    registry_name = TestRegistry
-    start_supervised!({ChatSessionRegistry, name: registry_name, supervisor: supervisor_pid})
-    Application.put_env(:slippi_chat, :chat_session_registry, TestRegistry)
-
-    %{registry_name: registry_name}
   end
 
   describe "Show" do

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -30,6 +30,8 @@ defmodule SlippiChatWeb.ChannelCase do
 
   setup tags do
     SlippiChat.DataCase.setup_sandbox(tags)
+    SlippiChat.Injections.set_chat_session_registry(tags.test)
+
     :ok
   end
 end

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -1,9 +1,9 @@
-defmodule SlippiChatWeb.ConnCase do
+defmodule SlippiChatWeb.ChannelCase do
   @moduledoc """
   This module defines the test case to be used by
-  tests that require setting up a connection.
+  channel tests.
 
-  Such tests rely on `Phoenix.ConnTest` and also
+  Such tests rely on `Phoenix.ChannelTest` and also
   import other functionality to make it easier
   to build common data structures and query the data layer.
 
@@ -11,7 +11,7 @@ defmodule SlippiChatWeb.ConnCase do
   we enable the SQL sandbox, so changes done to the database
   are reverted at the end of every test. If you are using
   PostgreSQL, you can even run database tests asynchronously
-  by setting `use SlippiChatWeb.ConnCase, async: true`, although
+  by setting `use SlippiChatWeb.ChannelCase, async: true`, although
   this option is not recommended for other databases.
   """
 
@@ -19,26 +19,17 @@ defmodule SlippiChatWeb.ConnCase do
 
   using do
     quote do
+      # Import conveniences for testing with channels
+      import Phoenix.ChannelTest
+      import SlippiChatWeb.ChannelCase
+
       # The default endpoint for testing
       @endpoint SlippiChatWeb.Endpoint
-
-      use SlippiChatWeb, :verified_routes
-
-      # Import conveniences for testing with connections
-      import Plug.Conn
-      import Phoenix.ConnTest
-      import SlippiChatWeb.ConnCase
     end
   end
 
   setup tags do
     SlippiChat.DataCase.setup_sandbox(tags)
-
-    # Shut down chat sessions
-    for {player_codes, pid} <- SlippiChat.ChatSessionRegistry.list_chat_sessions() do
-      GenServer.stop(pid)
-    end
-
-    {:ok, conn: Phoenix.ConnTest.build_conn()}
+    :ok
   end
 end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -33,11 +33,7 @@ defmodule SlippiChatWeb.ConnCase do
 
   setup tags do
     SlippiChat.DataCase.setup_sandbox(tags)
-
-    # Shut down chat sessions
-    for {player_codes, pid} <- SlippiChat.ChatSessionRegistry.list_chat_sessions() do
-      GenServer.stop(pid)
-    end
+    SlippiChat.Injections.set_chat_session_registry(tags.test)
 
     {:ok, conn: Phoenix.ConnTest.build_conn()}
   end

--- a/test/support/injections.ex
+++ b/test/support/injections.ex
@@ -1,7 +1,11 @@
 defmodule SlippiChat.Injections do
   def set_chat_session_registry(registry_name) do
     {:ok, chat_session_supervisor} = DynamicSupervisor.start_link(strategy: :one_for_one)
-    ExUnit.Callbacks.start_supervised!({SlippiChat.ChatSessionRegistry, name: registry_name, supervisor: chat_session_supervisor})
+
+    ExUnit.Callbacks.start_supervised!(
+      {SlippiChat.ChatSessionRegistry, name: registry_name, supervisor: chat_session_supervisor}
+    )
+
     Application.put_env(:slippi_chat, :chat_session_registry, registry_name)
   end
 end

--- a/test/support/injections.ex
+++ b/test/support/injections.ex
@@ -1,0 +1,7 @@
+defmodule SlippiChat.Injections do
+  def set_chat_session_registry(registry_name) do
+    {:ok, chat_session_supervisor} = DynamicSupervisor.start_link(strategy: :one_for_one)
+    ExUnit.Callbacks.start_supervised!({SlippiChat.ChatSessionRegistry, name: registry_name, supervisor: chat_session_supervisor})
+    Application.put_env(:slippi_chat, :chat_session_registry, registry_name)
+  end
+end


### PR DESCRIPTION
Currently, a `ChatSession` is spawned by keeping track of the current game of every online player, and spawning sessions when matches between players are found. This creates complexity because there is a layer of data between users `game_start`/`game_end` events and `ChatSession` processes. This complexity is not necessary; this PR addresses it by spawning a `ChatSession` process as soon as a single client starts a game with a new set of opponents.