### PR TITLE
Set client code on socket

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -20,6 +20,13 @@ if System.get_env("PHX_SERVER") do
   config :slippi_chat, SlippiChatWeb.Endpoint, server: true
 end
 
+config :slippi_chat, :chat_session_registry, SlippiChat.ChatSessionRegistry
+config :slippi_chat, :chat_session_timeout_ms, :timer.minutes(15)
+
+if config_env() == :test do
+  config :slippi_chat, :chat_session_timeout_ms, 150
+end
+
 if config_env() == :prod do
   database_url =
     System.get_env("DATABASE_URL") ||
@@ -62,9 +69,6 @@ if config_env() == :prod do
       port: port
     ],
     secret_key_base: secret_key_base
-
-  config :slippi_chat, :chat_session_timeout_ms, :timer.minutes(15)
-  config :slippi_chat, :chat_session_registry, SlippiChat.ChatSessionRegistry
 
   # ## SSL Support
   #

--- a/config/test.exs
+++ b/config/test.exs
@@ -23,8 +23,6 @@ config :slippi_chat, SlippiChatWeb.Endpoint,
 # In test we don't send emails.
 config :slippi_chat, SlippiChat.Mailer, adapter: Swoosh.Adapters.Test
 
-config :slippi_chat, :chat_session_timeout_ms, 150
-
 # Disable swoosh api client as it is only required for production adapters.
 config :swoosh, :api_client, false
 

--- a/lib/slippi_chat_web/channels/client_channel.ex
+++ b/lib/slippi_chat_web/channels/client_channel.ex
@@ -10,9 +10,9 @@ defmodule SlippiChatWeb.ClientChannel do
   end
 
   @impl true
-  def join("clients", payload, socket) do
-    if authorized?(payload) do
-      client_code = payload["client_code"]
+  def join("clients", _payload, socket) do
+    if authorized?(socket) do
+      client_code = socket.assigns.client_code
       Endpoint.subscribe(ChatSessions.player_topic(client_code))
       # TODO: More refined client tracking so not every LV instance receives every join
       Presence.track(socket, client_code, %{})
@@ -40,8 +40,8 @@ defmodule SlippiChatWeb.ClientChannel do
     end
   end
 
-  defp authorized?(payload) do
-    Map.has_key?(payload, "client_code") && is_binary(payload["client_code"])
+  defp authorized?(socket) do
+    Map.has_key?(socket.assigns, :client_code) && is_binary(socket.assigns.client_code)
   end
 
   @impl true

--- a/lib/slippi_chat_web/channels/user_socket.ex
+++ b/lib/slippi_chat_web/channels/user_socket.ex
@@ -16,8 +16,20 @@ defmodule SlippiChatWeb.UserSocket do
   # See `Phoenix.Token` documentation for examples in
   # performing token verification on connect.
   @impl true
-  def connect(_params, socket, _connect_info) do
-    {:ok, socket}
+  def connect(params, socket) do
+    with {:ok, client_code} <- get_client_code(params) do
+      {:ok, assign(socket, :client_code, client_code)}
+    else
+      _ -> :error
+    end
+  end
+
+  defp get_client_code(params) do
+    if Map.has_key?(params, "client_code") && is_binary(params["client_code"]) do
+      {:ok, params["client_code"]}
+    else
+      :error
+    end
   end
 
   # Socket id's are topics that allow you to identify all sockets for a given user:
@@ -31,5 +43,5 @@ defmodule SlippiChatWeb.UserSocket do
   #
   # Returning `nil` makes this socket anonymous.
   @impl true
-  def id(_socket), do: nil
+  def id(socket), do: "user_socket:#{socket.assigns.client_code}"
 end

--- a/test/slippi_chat_web/channels/client_channel_test.exs
+++ b/test/slippi_chat_web/channels/client_channel_test.exs
@@ -14,13 +14,12 @@ defmodule SlippiChatWeb.ClientChannelTest do
   end
 
   setup do
-    # TODO: Authorize socket on connection rather than channel join
     client_code = "ABC#123"
 
     {:ok, _reply, socket} =
       UserSocket
-      |> socket()
-      |> subscribe_and_join(ClientChannel, "clients", %{"client_code" => client_code})
+      |> socket("user_socket:#{client_code}", %{client_code: client_code})
+      |> subscribe_and_join(ClientChannel, "clients")
 
     %{client_code: client_code, socket: socket}
   end
@@ -31,8 +30,8 @@ defmodule SlippiChatWeb.ClientChannelTest do
 
       {:ok, _reply, _socket2} =
         UserSocket
-        |> socket()
-        |> subscribe_and_join(ClientChannel, "clients", %{"client_code" => "DEF#456"})
+        |> socket("user_socket:DEF#456", %{client_code: "DEF#456"})
+        |> subscribe_and_join(ClientChannel, "clients")
 
       assert Presence.list("clients") |> Map.keys() == ["ABC#123", "DEF#456"]
 

--- a/test/slippi_chat_web/live/game_live/root_test.exs
+++ b/test/slippi_chat_web/live/game_live/root_test.exs
@@ -99,24 +99,28 @@ defmodule SlippiChatWeb.GameLive.RootTest do
         refute html =~ "XYZ#987 (online)"
       end)
 
+      code_abc = "ABC#123"
+
       {:ok, _reply, socket_abc} =
         UserSocket
-        |> socket()
-        |> subscribe_and_join(ClientChannel, "clients", %{"client_code" => "ABC#123"})
+        |> socket("user_socket:#{code_abc}", %{client_code: code_abc})
+        |> subscribe_and_join(ClientChannel, "clients")
 
-      assert_broadcast "presence_diff", %{joins: %{"ABC#123" => _}}
+      assert_broadcast "presence_diff", %{joins: %{^code_abc => _}}
 
       Enum.each([render(lv1), render(lv2)], fn html ->
         assert html =~ "ABC#123 (online)"
         refute html =~ "XYZ#987 (online)"
       end)
 
+      code_xyz = "XYZ#987"
+
       {:ok, _reply, _socket_xyz} =
         UserSocket
-        |> socket()
-        |> subscribe_and_join(ClientChannel, "clients", %{"client_code" => "XYZ#987"})
+        |> socket(code_xyz, %{client_code: code_xyz})
+        |> subscribe_and_join(ClientChannel, "clients")
 
-      assert_broadcast "presence_diff", %{joins: %{"XYZ#987" => _}}
+      assert_broadcast "presence_diff", %{joins: %{^code_xyz => _}}
 
       Enum.each([render(lv1), render(lv2)], fn html ->
         assert html =~ "ABC#123 (online)"

--- a/test/support/injections.ex
+++ b/test/support/injections.ex
@@ -1,5 +1,7 @@
 defmodule SlippiChat.Injections do
   def set_chat_session_registry(registry_name) do
+    old_registry = Application.fetch_env!(:slippi_chat, :chat_session_registry)
+
     {:ok, chat_session_supervisor} = DynamicSupervisor.start_link(strategy: :one_for_one)
 
     ExUnit.Callbacks.start_supervised!(
@@ -7,5 +9,9 @@ defmodule SlippiChat.Injections do
     )
 
     Application.put_env(:slippi_chat, :chat_session_registry, registry_name)
+
+    ExUnit.Callbacks.on_exit(fn ->
+      Application.put_env(:slippi_chat, :chat_session_registry, old_registry)
+    end)
   end
 end


### PR DESCRIPTION
Previously, a socket would connect to a channel by providing its client code, with the socket being anonymous. This PR moves that authentication logic to the socket connect, and uses it to assign `client_code` to the socket, as well as provide a socket ID. The code is then used for authorization and identification when connecting to the `"clients"` channel topic.