### PR TITLE
De-flake tests

### DIFF
--- a/test/slippi_chat_web/live/game_live/root_test.exs
+++ b/test/slippi_chat_web/live/game_live/root_test.exs
@@ -108,9 +108,11 @@ defmodule SlippiChatWeb.GameLive.RootTest do
 
       assert_broadcast "presence_diff", %{joins: %{^code_abc => _}}
 
-      Enum.each([render(lv1), render(lv2)], fn html ->
-        assert html =~ "ABC#123 (online)"
-        refute html =~ "XYZ#987 (online)"
+      wait_until(fn ->
+        Enum.each([render(lv1), render(lv2)], fn html ->
+          assert html =~ "ABC#123 (online)"
+          refute html =~ "XYZ#987 (online)"
+        end)
       end)
 
       code_xyz = "XYZ#987"
@@ -122,18 +124,22 @@ defmodule SlippiChatWeb.GameLive.RootTest do
 
       assert_broadcast "presence_diff", %{joins: %{^code_xyz => _}}
 
-      Enum.each([render(lv1), render(lv2)], fn html ->
-        assert html =~ "ABC#123 (online)"
-        assert html =~ "XYZ#987 (online)"
+      wait_until(fn ->
+        Enum.each([render(lv1), render(lv2)], fn html ->
+          assert html =~ "ABC#123 (online)"
+          assert html =~ "XYZ#987 (online)"
+        end)
       end)
 
       Process.unlink(socket_abc.channel_pid)
       close(socket_abc)
       assert_broadcast "presence_diff", %{leaves: %{"ABC#123" => _}}
 
-      Enum.each([render(lv1), render(lv2)], fn html ->
-        refute html =~ "ABC#123 (online)"
-        assert html =~ "XYZ#987 (online)"
+      wait_until(fn ->
+        Enum.each([render(lv1), render(lv2)], fn html ->
+          refute html =~ "ABC#123 (online)"
+          assert html =~ "XYZ#987 (online)"
+        end)
       end)
     end
   end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -27,6 +27,7 @@ defmodule SlippiChatWeb.ConnCase do
       # Import conveniences for testing with connections
       import Plug.Conn
       import Phoenix.ConnTest
+      import SlippiChat.TimeHelper
       import SlippiChatWeb.ConnCase
     end
   end

--- a/test/support/time_helper.ex
+++ b/test/support/time_helper.ex
@@ -1,0 +1,15 @@
+defmodule SlippiChat.TimeHelper do
+  def wait_until(fun), do: wait_until(1_000, fun)
+
+  def wait_until(0, fun), do: fun.()
+
+  def wait_until(timeout, fun) do
+    try do
+      fun.()
+    rescue
+      ExUnit.AssertionError ->
+        :timer.sleep(10)
+        wait_until(max(0, timeout - 10), fun)
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes test flakes originating from assertions relying on PubSub messages processing before the assertion is run.