### PR TITLE
Implement and require token authentication

### DIFF
--- a/lib/slippi_chat/auth.ex
+++ b/lib/slippi_chat/auth.ex
@@ -1,0 +1,70 @@
+defmodule SlippiChat.Auth do
+  @moduledoc """
+  The Auth context.
+
+  Based on mix phx.gen.auth.
+  """
+
+  import Ecto.Query, warn: false
+  alias SlippiChat.Repo
+
+  alias SlippiChat.Auth.ClientToken
+
+  ## Session
+
+  @doc """
+  Generates a session token.
+
+  Returns `:error` if the granter token is not valid.
+  """
+  def generate_granted_session_token(client_code, granter_token) do
+    with {:ok, query} <- ClientToken.verify_hashed_token_query(granter_token, "session"),
+         granter_code when not is_nil(granter_code) <- Repo.one(query) do
+      build_and_insert_token(client_code, granter_code, granter_token)
+    else
+      _ -> :error
+    end
+  end
+
+  @doc """
+  Generates a session token without a granter.
+  """
+  def generate_admin_session_token(client_code) do
+    build_and_insert_token(client_code, nil, nil)
+  end
+
+  defp build_and_insert_token(client_code, granter_code, granter_token) do
+    {token, client_token} =
+      ClientToken.build_hashed_token(client_code, "session", granter_code, granter_token)
+
+    Repo.insert!(client_token)
+    token
+  end
+
+  @doc """
+  Gets the client_code for the given signed token.
+
+  Returns `nil` if the token doesn't exist or isn't valid.
+  """
+  def get_client_code_by_session_token(token) do
+    with {:ok, query} <- ClientToken.verify_hashed_token_query(token, "session") do
+      Repo.one(query)
+    else
+      _ -> nil
+    end
+  end
+
+  @doc """
+  Deletes a session token.
+  """
+  def delete_session_token(token) do
+    case Base.url_decode64(token, padding: false) do
+      {:ok, decoded_token} ->
+        Repo.delete_all(ClientToken.token_and_context_query(decoded_token, "session"))
+        :ok
+
+      :error ->
+        :error
+    end
+  end
+end

--- a/lib/slippi_chat/auth/client_token.ex
+++ b/lib/slippi_chat/auth/client_token.ex
@@ -1,0 +1,72 @@
+defmodule SlippiChat.Auth.ClientToken do
+  use Ecto.Schema
+  import Ecto.Query
+
+  @hash_algorithm :sha256
+  @rand_size 32
+
+  schema "clients_tokens" do
+    field :client_code, :string
+    field :token, :binary
+    field :context, :string
+    field :granter_code, :string
+    field :granter_token, :binary
+
+    timestamps(updated_at: false)
+  end
+
+  @doc """
+  Builds a token and its hash to be delivered to the client.
+
+  The non-hashed token is sent to the client while the
+  hashed part is stored in the database. The original token cannot be reconstructed,
+  which means anyone with read-only access to the database cannot directly use
+  the token in the application to gain access.
+  """
+  def build_hashed_token(client_code, context, granter_code, granter_token) do
+    token = :crypto.strong_rand_bytes(@rand_size)
+    hashed_token = :crypto.hash(@hash_algorithm, token)
+
+    {Base.url_encode64(token, padding: false),
+     %SlippiChat.Auth.ClientToken{
+       token: hashed_token,
+       context: context,
+       client_code: client_code,
+       granter_code: granter_code,
+       granter_token: granter_token
+     }}
+  end
+
+  @doc """
+  Checks if the token is valid and returns its underlying lookup query.
+
+  The query returns the client_code associated with the token, if any.
+
+  The given token is valid if it matches its hashed counterpart in the
+  database.
+  """
+  def verify_hashed_token_query(token, context) do
+    case Base.url_decode64(token, padding: false) do
+      {:ok, decoded_token} ->
+        # days = days_for_context(context)
+
+        query =
+          from token in token_and_context_query(decoded_token, context),
+            # where: token.inserted_at > ago(^days, "day") and token.sent_to == user.email,
+            select: token.client_code
+
+        {:ok, query}
+
+      :error ->
+        :error
+    end
+  end
+
+  @doc """
+  Returns the token struct for the given token value and context.
+  """
+  def token_and_context_query(token, context) do
+    hashed_token = :crypto.hash(@hash_algorithm, token)
+    from SlippiChat.Auth.ClientToken, where: [token: ^hashed_token, context: ^context]
+  end
+end

--- a/priv/repo/migrations/20230725115608_create_access_tokens.exs
+++ b/priv/repo/migrations/20230725115608_create_access_tokens.exs
@@ -1,0 +1,17 @@
+defmodule SlippiChat.Repo.Migrations.CreateAccessTokens do
+  use Ecto.Migration
+
+  def change do
+    create table(:clients_tokens) do
+      add :client_code, :string, null: false
+      add :token, :binary, null: false
+      add :context, :string, null: false
+      add :granter_code, :string, null: true
+      add :granter_token, :binary, null: true
+      timestamps(updated_at: false)
+    end
+
+    create index(:clients_tokens, [:token])
+    create unique_index(:clients_tokens, [:context, :token])
+  end
+end

--- a/test/slippi_chat/auth_test.exs
+++ b/test/slippi_chat/auth_test.exs
@@ -1,0 +1,78 @@
+defmodule SlippiChat.AuthTest do
+  use SlippiChat.DataCase, async: true
+
+  alias SlippiChat.Auth
+  alias SlippiChat.Auth.ClientToken
+
+  describe "generate_granted_session_token/2" do
+    test "generates a session token" do
+      granter_code = "ABC#123"
+      granter_token = Auth.generate_admin_session_token(granter_code)
+
+      client_code = "DEF#456"
+      token = Auth.generate_granted_session_token(client_code, granter_token)
+      {:ok, token} = Base.url_decode64(token, padding: false)
+
+      assert client_token = Repo.get_by(ClientToken, token: :crypto.hash(:sha256, token))
+      assert client_token.context == "session"
+      assert client_token.client_code == client_code
+      assert client_token.granter_code == granter_code
+      assert client_token.granter_token == granter_token
+    end
+
+    test "does not generate a token with an invalid granter token" do
+      assert Auth.generate_granted_session_token("ABC#123", "invalid token") == :error
+    end
+  end
+
+  describe "generate_admin_session_token/1" do
+    test "generates a session token" do
+      client_code = "ABC#123"
+      token = Auth.generate_admin_session_token(client_code)
+      {:ok, token} = Base.url_decode64(token, padding: false)
+
+      assert client_token = Repo.get_by(ClientToken, token: :crypto.hash(:sha256, token))
+      assert client_token.context == "session"
+      assert client_token.client_code == client_code
+    end
+  end
+
+  describe "get_client_code_by_session_token/1" do
+    test "returns the client code for a valid token" do
+      client_code = "ABC#123"
+      token = Auth.generate_admin_session_token(client_code)
+
+      assert Auth.get_client_code_by_session_token(token) == client_code
+    end
+
+    test "returns `nil` for an invalid token" do
+      assert Auth.get_client_code_by_session_token(":)") == nil
+      assert Auth.get_client_code_by_session_token(Base.url_encode64(":)", padding: false)) == nil
+    end
+  end
+
+  describe "delete_session_token/1" do
+    test "deletes a valid token" do
+      client_code = "ABC#123"
+      token = Auth.generate_admin_session_token(client_code)
+      {:ok, decoded_token} = Base.url_decode64(token, padding: false)
+
+      assert %ClientToken{} =
+               Repo.get_by(ClientToken, token: :crypto.hash(:sha256, decoded_token))
+
+      assert Auth.delete_session_token(token) == :ok
+      assert Repo.get_by(ClientToken, token: :crypto.hash(:sha256, decoded_token)) == nil
+    end
+
+    test "returns :error if token is not base64" do
+      assert Auth.delete_session_token(":)") == :error
+    end
+
+    test "deletes nothing if token is not valid" do
+      count_before = Repo.aggregate(ClientToken, :count, :id)
+      assert Auth.delete_session_token(Base.url_encode64(":)", padding: false)) == :ok
+      count_after = Repo.aggregate(ClientToken, :count, :id)
+      assert count_before == count_after
+    end
+  end
+end

--- a/test/slippi_chat_web/channels/user_socket_test.exs
+++ b/test/slippi_chat_web/channels/user_socket_test.exs
@@ -1,0 +1,32 @@
+defmodule SlippiChatWeb.UserSocketTest do
+  use SlippiChatWeb.ChannelCase, async: false
+
+  alias SlippiChat.Auth
+  alias SlippiChatWeb.UserSocket
+
+  setup do
+    %{socket: socket(UserSocket)}
+  end
+
+  describe "connect" do
+    test "requires a session token", %{socket: socket} do
+      client_code = "ABC#123"
+      client_token = Auth.generate_admin_session_token(client_code)
+
+      assert {:ok, socket} = UserSocket.connect(%{"client_token" => client_token}, socket)
+      assert socket.assigns.client_code == client_code
+    end
+
+    test "refuses connection with no token specified", %{socket: socket} do
+      assert UserSocket.connect(%{}, socket) == :error
+    end
+
+    test "refuses connection on invalid session token", %{socket: socket} do
+      fake_token = "fake token"
+      encoded_fake_token = Base.url_encode64("fake token", padding: false)
+
+      assert UserSocket.connect(%{"client_token" => fake_token}, socket) == :error
+      assert UserSocket.connect(%{"client_token" => encoded_fake_token}, socket) == :error
+    end
+  end
+end

--- a/test/slippi_chat_web/live/game_live/root_test.exs
+++ b/test/slippi_chat_web/live/game_live/root_test.exs
@@ -151,9 +151,9 @@ defmodule SlippiChatWeb.GameLive.RootTest do
       {:ok, pid} =
         ChatSessionRegistry.start_chat_session(chat_session_registry(), ["ABC#123", "XYZ#987"])
 
-      {:ok, lv, html} = live(conn, ~p"/chat/abc-123")
+      {:ok, lv, _html} = live(conn, ~p"/chat/abc-123")
 
-      assert html =~ "Chat session players:"
+      html = render_until(lv, fn html -> assert html =~ "Chat session players:" end)
       assert html =~ "XYZ#987"
 
       ChatSession.send_message(pid, "ABC#123", "test message")
@@ -161,8 +161,7 @@ defmodule SlippiChatWeb.GameLive.RootTest do
 
       ChatSession.end_session(pid)
 
-      wait_until(fn -> assert render(lv) =~ "No chat session in progress." end)
-      html = render(lv)
+      html = render_until(lv, fn html -> assert html =~ "No chat session in progress." end)
       refute html =~ "XYZ#987"
       refute html =~ "test message"
     end
@@ -171,9 +170,9 @@ defmodule SlippiChatWeb.GameLive.RootTest do
       {:ok, pid} =
         ChatSessionRegistry.start_chat_session(chat_session_registry(), ["ABC#123", "XYZ#987"])
 
-      {:ok, lv, html} = live(conn, ~p"/chat/abc-123")
+      {:ok, lv, _html} = live(conn, ~p"/chat/abc-123")
 
-      assert html =~ "Chat session players:"
+      html = render_until(lv, fn html -> assert html =~ "Chat session players:" end)
       assert html =~ "XYZ#987"
 
       ChatSession.send_message(pid, "ABC#123", "test message")
@@ -183,8 +182,7 @@ defmodule SlippiChatWeb.GameLive.RootTest do
         ChatSessionRegistry.start_chat_session(chat_session_registry(), ["ABC#123", "DEF#456"])
 
       wait_until(fn -> assert render(lv) =~ "DEF#456" end)
-      wait_until(fn -> refute render(lv) =~ "test message" end)
-      html = render(lv)
+      html = render_until(lv, fn html -> refute html =~ "test message" end)
       refute html =~ "XYZ#987"
       refute html =~ "test message"
     end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -38,4 +38,25 @@ defmodule SlippiChatWeb.ConnCase do
 
     {:ok, conn: Phoenix.ConnTest.build_conn()}
   end
+
+  @doc """
+  Wait for a LiveView html-based assertion to pass.
+
+  Accepts a LiveView from Phoenix.LiveViewTest.live/2, and a function
+  of arity 1, which gets passed the rendered LiveView and does assertions
+  on the html. Returns the rendered html which passed the assertion.
+
+  ## Examples
+
+      iex> html = render_until(lv, fn html -> assert html =~ "Loading finished!" end)
+  """
+  def render_until(lv, fun) do
+    wrapped_fun = fn ->
+      html = Phoenix.LiveViewTest.render(lv)
+      fun.(html)
+      html
+    end
+
+    SlippiChat.TimeHelper.wait_until(wrapped_fun)
+  end
 end


### PR DESCRIPTION
This is the first PR in a series to secure access to SlippiChat. The high-level view looks like:

1. Require an encoded token to connect to the socket
2. Use the token for access to the chat LiveView
3. Create a flow to grant new tokens by having unverified clients connect on Slippi to a verified client and ensuring appropriate `game_start` events are received within a certain amount of time of one-another from both clients

This PR accomplishes bullet 1. For now, tokens do not expire so they aren't refreshed. Initial tokens can be created by an admin with access to the deployment shell.