### PR TITLE
Reply to channel join with client connect code

### DIFF
--- a/lib/slippi_chat_web/channels/client_channel.ex
+++ b/lib/slippi_chat_web/channels/client_channel.ex
@@ -34,7 +34,7 @@ defmodule SlippiChatWeb.ClientChannel do
             |> assign(:current_session_player_codes, nil)
         end
 
-      {:ok, socket}
+      {:ok, %{connect_code: client_code}, socket}
     else
       {:error, %{reason: "unauthorized"}}
     end

--- a/test/slippi_chat_web/channels/client_channel_test.exs
+++ b/test/slippi_chat_web/channels/client_channel_test.exs
@@ -28,11 +28,12 @@ defmodule SlippiChatWeb.ClientChannelTest do
     test "tracks via Presence", %{socket: socket1} do
       assert Presence.list("clients") |> Map.keys() == ["ABC#123"]
 
-      {:ok, _reply, _socket2} =
+      {:ok, reply, _socket2} =
         UserSocket
         |> socket("user_socket:DEF#456", %{client_code: "DEF#456"})
         |> subscribe_and_join(ClientChannel, "clients")
 
+      assert reply == %{connect_code: "DEF#456"}
       assert Presence.list("clients") |> Map.keys() == ["ABC#123", "DEF#456"]
 
       Process.unlink(socket1.channel_pid)


### PR DESCRIPTION
The client does not necessarily know its connect code, just its access token. This PR provides the client with its connect code upon successful `"clients"` channel join.