### PR TITLE
Magic login flow

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -22,6 +22,7 @@ end
 
 config :slippi_chat, :chat_session_registry, SlippiChat.ChatSessionRegistry
 config :slippi_chat, :chat_session_timeout_ms, :timer.minutes(15)
+config :slippi_chat, :magic_authenticator, SlippiChat.Auth.MagicAuthenticator
 
 if config_env() == :test do
   config :slippi_chat, :chat_session_timeout_ms, 150

--- a/lib/slippi_chat/application.ex
+++ b/lib/slippi_chat/application.ex
@@ -22,7 +22,8 @@ defmodule SlippiChat.Application do
       SlippiChatWeb.Endpoint,
       # Start a worker by calling: SlippiChat.Worker.start_link(arg)
       # {SlippiChat.Worker, arg}
-      {SlippiChat.ChatSessions.Supervisor, name: SlippiChat.ChatSessions.Supervisor}
+      {SlippiChat.ChatSessions.Supervisor, name: SlippiChat.ChatSessions.Supervisor},
+      {SlippiChat.Auth.MagicAuthenticator, name: SlippiChat.Auth.MagicAuthenticator}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/slippi_chat/auth.ex
+++ b/lib/slippi_chat/auth.ex
@@ -82,6 +82,22 @@ defmodule SlippiChat.Auth do
   end
 
   @doc """
+  Generates a token to be used in the magic login flow.
+  """
+  def generate_magic_token(client_code) do
+    build_and_insert_signed_token(client_code, "magic")
+  end
+
+  @doc """
+  Gets the client_code for the given magic token.
+
+  Returns `nil` if the token doesn't exist or isn't valid.
+  """
+  def get_client_code_by_magic_token(client_code) do
+    get_client_code_by_signed_token(client_code, "magic")
+  end
+
+  @doc """
   Generates a token for logging in a user.
   """
   def generate_login_token(client_code) do
@@ -108,6 +124,13 @@ defmodule SlippiChat.Auth do
 
     Repo.delete_all(query)
   end
+
+  defp build_and_insert_signed_token(client_code, context) do
+    {token, client_token} = ClientToken.build_hashed_token(client_code, context)
+    Repo.insert!(client_token)
+    token
+  end
+
   @doc """
   Gets the client_code for the given signed token.
 

--- a/lib/slippi_chat/auth.ex
+++ b/lib/slippi_chat/auth.ex
@@ -73,12 +73,48 @@ defmodule SlippiChat.Auth do
   end
 
   @doc """
+  Gets the client_code for the given client token.
+
+  Returns `nil` if the token doesn't exist or isn't valid.
+  """
+  def get_client_code_by_client_token(client_code) do
+    get_client_code_by_signed_token(client_code, "client")
+  end
+
+  @doc """
+  Generates a token for logging in a user.
+  """
+  def generate_login_token(client_code) do
+    build_and_insert_signed_token(client_code, "login")
+  end
+
+  @doc """
+  Gets the client_code for the given login token.
+
+  Returns `nil` if the token doesn't exist or isn't valid.
+  """
+  def get_client_code_by_login_token(client_code) do
+    get_client_code_by_signed_token(client_code, "login")
+  end
+
+  @doc """
+  Removes all login tokens for a client_code from the database.
+  """
+  def delete_login_tokens(client_code) do
+    query =
+      from t in ClientToken,
+        where: t.context == "login",
+        where: t.client_code == ^client_code
+
+    Repo.delete_all(query)
+  end
+  @doc """
   Gets the client_code for the given signed token.
 
   Returns `nil` if the token doesn't exist or isn't valid.
   """
-  def get_client_code_by_client_token(token) do
-    with {:ok, query} <- ClientToken.verify_hashed_token_query(token, "client") do
+  def get_client_code_by_signed_token(token, context) do
+    with {:ok, query} <- ClientToken.verify_hashed_token_query(token, context) do
       Repo.one(query)
     else
       _ -> nil

--- a/lib/slippi_chat/auth/magic_authenticator.ex
+++ b/lib/slippi_chat/auth/magic_authenticator.ex
@@ -1,0 +1,93 @@
+defmodule SlippiChat.Auth.MagicAuthenticator do
+  @moduledoc """
+  A GenServer for tracking and authenticating LiveView pids
+  in the magic login flow.
+  """
+  use GenServer
+
+  alias SlippiChat.Auth
+
+  defstruct registrations: %{}, used_codes: MapSet.new()
+
+  @verification_code_length 6
+
+  ## API
+
+  @doc """
+  Starts MagicAuthenticator with the given options.
+
+  `:name` is always required.
+  """
+  def start_link(opts) do
+    server_name = Keyword.fetch!(opts, :name)
+    GenServer.start_link(__MODULE__, nil, name: server_name)
+  end
+
+  @doc """
+  Generate a verification code for a client code. Registers the calling
+  process as the receiver of the login token when the client code +
+  returned verification code are verified.
+  """
+  @spec register_verification_code(GenServer.server(), String.t()) :: String.t()
+  def register_verification_code(server, client_code) do
+    GenServer.call(server, {:register_verification_code, client_code})
+  end
+
+  @doc """
+  Verify a combination of client code and verification code.
+  """
+  @spec verify(GenServer.server(), String.t(), String.t()) :: boolean()
+  def verify(server, client_code, verification_code) do
+    GenServer.call(server, {:verify, client_code, verification_code})
+  end
+
+  ## Callbacks
+
+  @impl true
+  def init(_) do
+    state = %__MODULE__{}
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call({:register_verification_code, client_code}, {from_pid, _tag}, state) do
+    verification_code = unique_random_code(state.used_codes)
+    new_regs = Map.put_new(state.registrations, {client_code, verification_code}, from_pid)
+    new_used_codes = MapSet.put(state.used_codes, verification_code)
+    {:reply, verification_code, %{state | registrations: new_regs, used_codes: new_used_codes}}
+  end
+
+  def handle_call({:verify, client_code, verification_code}, _from, state) do
+    case Map.get(state.registrations, {client_code, verification_code}) do
+      nil ->
+        {:reply, false, state}
+
+      pid when is_pid(pid) ->
+        login_token = Auth.generate_login_token(client_code)
+        send(pid, {:verified, %{login_token: login_token}})
+        new_regs = Map.delete(state.registrations, {client_code, verification_code})
+        new_used_codes = MapSet.delete(state.used_codes, verification_code)
+
+        {:reply, true, %{state | registrations: new_regs, used_codes: new_used_codes}}
+    end
+  end
+
+  defp unique_random_code(used_codes) do
+    test_code = random_code()
+
+    if MapSet.member?(used_codes, test_code) do
+      unique_random_code(used_codes)
+    else
+      test_code
+    end
+  end
+
+  defp random_code do
+    symbols = ~c"0123456789"
+    symbol_count = Enum.count(symbols)
+
+    for _ <- 1..@verification_code_length, into: "" do
+      <<Enum.at(symbols, :rand.uniform(symbol_count) - 1)>>
+    end
+  end
+end

--- a/lib/slippi_chat_web/controllers/user_session_controller.ex
+++ b/lib/slippi_chat_web/controllers/user_session_controller.ex
@@ -2,18 +2,31 @@ defmodule SlippiChatWeb.UserSessionController do
   use SlippiChatWeb, :controller
 
   alias SlippiChat.Auth
+  alias SlippiChat.Auth.MagicAuthenticator
   alias SlippiChatWeb.UserAuth
 
-  def create(conn, %{"_action" => "registered"} = params) do
-    create(conn, params, "Account created successfully!")
+  defp magic_authenticator do
+    Application.fetch_env!(:slippi_chat, :magic_authenticator)
   end
 
-  def create(conn, params) do
-    create(conn, params, "Welcome back!")
+  def create(conn, %{"login_token" => login_token} = params) do
+    params = params |> Map.delete("login_token") |> Map.put("token", login_token)
+
+    create(conn, params, "login", "Logged in magically!")
   end
 
-  defp create(conn, %{"client_token" => client_token} = params, info) do
-    if client_code = Auth.get_client_code_by_client_token(client_token) do
+  def create(conn, %{"client_token" => client_token} = params) do
+    params = params |> Map.delete("client_token") |> Map.put("token", client_token)
+
+    create(conn, params, "client", "Welcome back!")
+  end
+
+  defp create(conn, %{"token" => token} = params, context, info) do
+    if client_code = Auth.get_client_code_by_signed_token(token, context) do
+      if context == "login" do
+        Auth.delete_login_tokens(client_code)
+      end
+
       conn
       |> put_flash(:info, info)
       |> UserAuth.log_in_user(client_code, params)
@@ -21,6 +34,21 @@ defmodule SlippiChatWeb.UserSessionController do
       conn
       |> put_flash(:error, "Invalid token")
       |> redirect(to: ~p"/log_in")
+    end
+  end
+
+  def verify(conn, %{"verification_code" => verification_code}) do
+    client_code = conn.assigns[:current_user_code]
+
+    if MagicAuthenticator.verify(magic_authenticator(), client_code, verification_code) do
+      conn
+      |> put_status(:ok)
+      |> render(:"200")
+    else
+      conn
+      |> put_status(:unauthorized)
+      |> put_view(SlippiChatWeb.ErrorJSON)
+      |> render(:"401")
     end
   end
 

--- a/lib/slippi_chat_web/controllers/user_session_json.ex
+++ b/lib/slippi_chat_web/controllers/user_session_json.ex
@@ -1,0 +1,5 @@
+defmodule SlippiChatWeb.UserSessionJSON do
+  def render(template, _assigns) do
+    Phoenix.Controller.status_message_from_template(template)
+  end
+end

--- a/lib/slippi_chat_web/endpoint.ex
+++ b/lib/slippi_chat_web/endpoint.ex
@@ -51,5 +51,6 @@ defmodule SlippiChatWeb.Endpoint do
   plug Plug.MethodOverride
   plug Plug.Head
   plug Plug.Session, @session_options
+  plug CORSPlug
   plug SlippiChatWeb.Router
 end

--- a/lib/slippi_chat_web/live/magic_login_live.ex
+++ b/lib/slippi_chat_web/live/magic_login_live.ex
@@ -1,0 +1,84 @@
+defmodule SlippiChatWeb.MagicLoginLive do
+  use SlippiChatWeb, :live_view
+  require Logger
+
+  alias SlippiChat.Auth
+  alias SlippiChat.Auth.MagicAuthenticator
+
+  defp magic_authenticator do
+    Application.fetch_env!(:slippi_chat, :magic_authenticator)
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="mx-auto max-w-sm">
+      <.header class="text-center">
+        Magic login
+      </.header>
+
+      <div class="text-center mt-12">
+        <div>Your magic code is</div>
+        <div class="mt-6 text-6xl">
+          <%= @verification_code %>
+        </div>
+      </div>
+
+      <.simple_form
+        id="redirect_form"
+        class="hidden"
+        for={@form}
+        action={~p"/log_in"}
+        phx-trigger-action={@trigger_submit}
+      >
+        <.input type="text" field={@form[:login_token]} />
+
+        <:actions>
+          <.button type="submit">Submit</.button>
+        </:actions>
+      </.simple_form>
+    </div>
+    """
+  end
+
+  @impl true
+  def mount(%{"t" => magic_token}, _session, socket) do
+    if client_code = Auth.get_client_code_by_magic_token(magic_token) do
+      verification_code =
+        if connected?(socket) do
+          MagicAuthenticator.register_verification_code(magic_authenticator(), client_code)
+        else
+          nil
+        end
+
+      form = to_form(%{"login_token" => nil})
+
+      {:ok,
+       socket
+       |> assign(:client_code, client_code)
+       |> assign(:verification_code, verification_code)
+       |> assign(:form, form)
+       |> assign(:trigger_submit, false), temporary_assigns: [form: form]}
+    else
+      {:ok,
+       socket
+       |> put_flash(:error, "Invalid magic token")
+       |> redirect(to: ~p"/log_in")}
+    end
+  end
+
+  def mount(_params, _session, socket) do
+    {:ok, redirect(socket, to: ~p"/log_in")}
+  end
+
+  @impl true
+  def handle_info({:verified, %{login_token: login_token}}, socket) do
+    {:noreply,
+     assign(socket, form: to_form(%{"login_token" => login_token}), trigger_submit: true)}
+  end
+
+  def handle_info(message, socket) do
+    Logger.debug("MagicLoginLive - unhandled message: #{inspect(message)}")
+    {:noreply, socket}
+  end
+end

--- a/lib/slippi_chat_web/router.ex
+++ b/lib/slippi_chat_web/router.ex
@@ -15,6 +15,7 @@ defmodule SlippiChatWeb.Router do
 
   pipeline :api do
     plug :accepts, ["json"]
+    plug :fetch_current_user_code
   end
 
   scope "/", SlippiChatWeb do
@@ -40,6 +41,7 @@ defmodule SlippiChatWeb.Router do
     live_session :redirect_if_user_is_authenticated,
       on_mount: [{SlippiChatWeb.UserAuth, :redirect_if_user_is_authenticated}] do
       live "/log_in", UserLoginLive, :new
+      live "/magic_log_in", MagicLoginLive, :new
     end
 
     post "/log_in", UserSessionController, :create
@@ -51,10 +53,11 @@ defmodule SlippiChatWeb.Router do
     delete "/log_out", UserSessionController, :delete
   end
 
-  # Other scopes may use custom stacks.
-  # scope "/api", SlippiChatWeb do
-  #   pipe_through :api
-  # end
+  scope "/", SlippiChatWeb do
+    pipe_through [:api, :require_authenticated_user]
+
+    post "/magic_verify", UserSessionController, :verify
+  end
 
   # Enable LiveDashboard and Swoosh mailbox preview in development
   if Application.compile_env(:slippi_chat, :dev_routes) do

--- a/mix.exs
+++ b/mix.exs
@@ -49,7 +49,8 @@ defmodule SlippiChat.MixProject do
       {:telemetry_poller, "~> 1.0"},
       {:gettext, "~> 0.20"},
       {:jason, "~> 1.2"},
-      {:plug_cowboy, "~> 2.5"}
+      {:plug_cowboy, "~> 2.5"},
+      {:cors_plug, "~> 3.0"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,7 @@
 %{
   "castore": {:hex, :castore, "1.0.3", "7130ba6d24c8424014194676d608cb989f62ef8039efd50ff4b3f33286d06db8", [:mix], [], "hexpm", "680ab01ef5d15b161ed6a95449fac5c6b8f60055677a8e79acf01b27baa4390b"},
   "connection": {:hex, :connection, "1.1.0", "ff2a49c4b75b6fb3e674bfc5536451607270aac754ffd1bdfe175abe4a6d7a68", [:mix], [], "hexpm", "722c1eb0a418fbe91ba7bd59a47e28008a189d47e37e0e7bb85585a016b2869c"},
+  "cors_plug": {:hex, :cors_plug, "3.0.3", "7c3ac52b39624bc616db2e937c282f3f623f25f8d550068b6710e58d04a0e330", [:mix], [{:plug, "~> 1.13", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm", "3f2d759e8c272ed3835fab2ef11b46bddab8c1ab9528167bd463b6452edf830d"},
   "cowboy": {:hex, :cowboy, "2.10.0", "ff9ffeff91dae4ae270dd975642997afe2a1179d94b1887863e43f681a203e26", [:make, :rebar3], [{:cowlib, "2.12.1", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "1.8.0", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm", "3afdccb7183cc6f143cb14d3cf51fa00e53db9ec80cdcd525482f5e99bc41d6b"},
   "cowboy_telemetry": {:hex, :cowboy_telemetry, "0.4.0", "f239f68b588efa7707abce16a84d0d2acf3a0f50571f8bb7f56a15865aae820c", [:rebar3], [{:cowboy, "~> 2.7", [hex: :cowboy, repo: "hexpm", optional: false]}, {:telemetry, "~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "7d98bac1ee4565d31b62d59f8823dfd8356a169e7fcbb83831b8a5397404c9de"},
   "cowlib": {:hex, :cowlib, "2.12.1", "a9fa9a625f1d2025fe6b462cb865881329b5caff8f1854d1cbc9f9533f00e1e1", [:make, :rebar3], [], "hexpm", "163b73f6367a7341b33c794c4e88e7dbfe6498ac42dcd69ef44c5bc5507c8db0"},

--- a/test/slippi_chat/auth/magic_authenticator_test.exs
+++ b/test/slippi_chat/auth/magic_authenticator_test.exs
@@ -1,0 +1,59 @@
+defmodule SlippiChat.Auth.MagicAuthenticatorTest do
+  use SlippiChat.DataCase, async: true
+
+  alias SlippiChat.Auth.MagicAuthenticator
+
+  setup %{test: name} do
+    client_code = "ABC#123"
+    pid = start_supervised!({MagicAuthenticator, name: name})
+    Ecto.Adapters.SQL.Sandbox.allow(SlippiChat.Repo, self(), pid)
+
+    %{pid: pid, client_code: client_code}
+  end
+
+  describe "register_verification_code/2" do
+    test "generates a verification code", %{pid: pid, client_code: client_code} do
+      verification_code = MagicAuthenticator.register_verification_code(pid, client_code)
+      assert Regex.match?(~r/^\d{6}$/, verification_code)
+    end
+  end
+
+  describe "verify/3" do
+    setup %{pid: pid, client_code: client_code} do
+      verification_code = MagicAuthenticator.register_verification_code(pid, client_code)
+      %{verification_code: verification_code}
+    end
+
+    test "verifies a valid client code + verification code combo", %{
+      pid: pid,
+      client_code: client_code,
+      verification_code: verification_code
+    } do
+      assert MagicAuthenticator.verify(pid, client_code, verification_code) == true
+    end
+
+    test "does not verify a valid verification code with the wrong client code", %{
+      pid: pid,
+      verification_code: verification_code
+    } do
+      assert MagicAuthenticator.verify(pid, "XYZ#987", verification_code) == false
+    end
+
+    test "does not verify a valid client code with the wrong verification", %{
+      pid: pid,
+      client_code: client_code,
+      verification_code: verification_code
+    } do
+      assert MagicAuthenticator.verify(pid, client_code, verification_code <> "fake") == false
+    end
+
+    test "does not verify a valid client code + verification code combo twice", %{
+      pid: pid,
+      client_code: client_code,
+      verification_code: verification_code
+    } do
+      assert MagicAuthenticator.verify(pid, client_code, verification_code) == true
+      assert MagicAuthenticator.verify(pid, client_code, verification_code) == false
+    end
+  end
+end

--- a/test/slippi_chat/auth_test.exs
+++ b/test/slippi_chat/auth_test.exs
@@ -90,17 +90,21 @@ defmodule SlippiChat.AuthTest do
     end
   end
 
-  describe "get_client_code_by_client_token/1" do
+  describe "get_client_code_by_signed_token/2" do
     test "returns the client code for a valid token" do
       client_code = "ABC#123"
       token = Auth.generate_admin_client_token(client_code)
 
-      assert Auth.get_client_code_by_client_token(token) == client_code
+      assert Auth.get_client_code_by_signed_token(token, "client") == client_code
     end
 
     test "returns `nil` for an invalid token" do
-      assert Auth.get_client_code_by_client_token(":)") == nil
-      assert Auth.get_client_code_by_client_token(Base.url_encode64(":)", padding: false)) == nil
+      assert Auth.get_client_code_by_signed_token(":)", "client") == nil
+
+      assert Auth.get_client_code_by_signed_token(
+               Base.url_encode64(":)", padding: false),
+               "client"
+             ) == nil
     end
   end
 end

--- a/test/slippi_chat_web/controllers/user_session_controller_test.exs
+++ b/test/slippi_chat_web/controllers/user_session_controller_test.exs
@@ -2,33 +2,54 @@ defmodule SlippiChatWeb.UserSessionControllerTest do
   use SlippiChatWeb.ConnCase, async: true
 
   alias SlippiChat.Auth
+  alias SlippiChat.Auth.MagicAuthenticator
+
+  defp magic_authenticator do
+    Application.fetch_env!(:slippi_chat, :magic_authenticator)
+  end
 
   setup do
     client_code = "ABC#123"
-    token = Auth.generate_admin_client_token(client_code)
+    client_token = Auth.generate_admin_client_token(client_code)
 
-    %{client_code: client_code, token: token}
+    %{client_code: client_code, client_token: client_token}
   end
 
   describe "POST /log_in" do
-    test "logs the user in", %{conn: conn, client_code: client_code, token: token} do
+    test "logs the user in via client token", %{
+      conn: conn,
+      client_code: client_code,
+      client_token: client_token
+    } do
       conn =
-        post(conn, ~p"/log_in", %{"client_token" => token})
+        post(conn, ~p"/log_in", %{"client_token" => client_token})
 
       assert get_session(conn, :user_token)
       assert redirected_to(conn) == ~p"/"
 
-      # Now do a logged in request and assert on the menu
       conn = get(conn, ~p"/chat")
       response = html_response(conn, 200)
       assert response =~ client_code
       assert response =~ ~p"/log_out"
     end
 
-    test "logs the user in with remember me", %{conn: conn, token: token} do
+    test "logs the user in via login token", %{conn: conn, client_code: client_code} do
+      login_token = Auth.generate_login_token(client_code)
+      conn = post(conn, ~p"/log_in", %{"login_token" => login_token})
+
+      assert get_session(conn, :user_token)
+      assert redirected_to(conn) == ~p"/"
+
+      conn = get(conn, ~p"/chat")
+      response = html_response(conn, 200)
+      assert response =~ client_code
+      assert response =~ ~p"/log_out"
+    end
+
+    test "logs the user in with remember me", %{conn: conn, client_token: client_token} do
       conn =
         post(conn, ~p"/log_in", %{
-          "client_token" => token,
+          "client_token" => client_token,
           "remember_me" => "true"
         })
 
@@ -36,33 +57,88 @@ defmodule SlippiChatWeb.UserSessionControllerTest do
       assert redirected_to(conn) == ~p"/"
     end
 
-    test "logs the user in with return to", %{conn: conn, token: token} do
+    test "logs the user in with return to", %{conn: conn, client_token: client_token} do
       conn =
         conn
         |> init_test_session(user_return_to: "/foo/bar")
-        |> post(~p"/log_in", %{"client_token" => token})
+        |> post(~p"/log_in", %{"client_token" => client_token})
 
       assert redirected_to(conn) == "/foo/bar"
       assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "Welcome back!"
     end
 
-    test "login following registration", %{conn: conn, token: token} do
-      conn =
-        conn
-        |> post(~p"/log_in", %{
-          "_action" => "registered",
-          "client_token" => token
-        })
-
-      assert redirected_to(conn) == ~p"/"
-      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "Account created successfully"
-    end
-
     test "redirects to login page with invalid credentials", %{conn: conn} do
-      conn = post(conn, ~p"/log_in", %{"client_token" => "fake token"})
+      conn = post(conn, ~p"/log_in", %{"client_token" => "fake client_token"})
 
       assert Phoenix.Flash.get(conn.assigns.flash, :error) == "Invalid token"
       assert redirected_to(conn) == ~p"/log_in"
+    end
+  end
+
+  describe "POST /magic_verify" do
+    setup do
+      allow = Process.whereis(magic_authenticator())
+      Ecto.Adapters.SQL.Sandbox.allow(SlippiChat.Repo, self(), allow)
+      %{}
+    end
+
+    test "requires authorization", %{conn: conn, client_code: client_code} do
+      verification_code =
+        MagicAuthenticator.register_verification_code(magic_authenticator(), client_code)
+
+      conn = post(conn, ~p"/magic_verify", %{"verification_code" => verification_code})
+
+      assert json_response(conn, 401) == %{"errors" => %{"detail" => "Unauthorized"}}
+      refute_receive {:verified, _data}
+    end
+
+    test "does not authorize invalid verification code", %{conn: conn, client_token: client_token} do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{client_token}")
+        |> post(~p"/magic_verify", %{"verification_code" => "12345"})
+
+      assert json_response(conn, 401) == %{"errors" => %{"detail" => "Unauthorized"}}
+      refute_receive {:verified, _data}
+    end
+
+    test "does not authorize with a different user's client token", %{
+      conn: conn,
+      client_code: client_code
+    } do
+      SlippiChatWeb.Endpoint.subscribe("magic_login:#{client_code}")
+      diff_client_token = Auth.generate_admin_client_token("XYZ#987")
+
+      verification_code =
+        MagicAuthenticator.register_verification_code(magic_authenticator(), client_code)
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{diff_client_token}")
+        |> post(~p"/magic_verify", %{"verification_code" => verification_code})
+
+      assert json_response(conn, 401) == %{"errors" => %{"detail" => "Unauthorized"}}
+      refute_receive {:verified, _data}
+    end
+
+    test "sends a login token via pubsub on successful verification", %{
+      conn: conn,
+      client_code: client_code,
+      client_token: client_token
+    } do
+      SlippiChatWeb.Endpoint.subscribe("magic_login:#{client_code}")
+
+      verification_code =
+        MagicAuthenticator.register_verification_code(magic_authenticator(), client_code)
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{client_token}")
+        |> post(~p"/magic_verify", %{"verification_code" => verification_code})
+
+      assert json_response(conn, 200) == "OK"
+      assert_receive {:verified, %{login_token: login_token}}
+      assert Auth.get_client_code_by_login_token(login_token) == client_code
     end
   end
 

--- a/test/slippi_chat_web/live/magic_login_live_test.exs
+++ b/test/slippi_chat_web/live/magic_login_live_test.exs
@@ -1,0 +1,71 @@
+defmodule SlippiChatWeb.MagicLoginLiveTest do
+  use SlippiChatWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  alias SlippiChat.Auth
+
+  describe "GET /magic_log_in" do
+    setup do
+      %{client_code: "ABC#123"}
+    end
+
+    test "rejects an invalid magic token", %{conn: conn} do
+      {:error, {:redirect, %{to: "/log_in", flash: %{"error" => "Invalid magic token"}}}} =
+        live(conn, ~p"/magic_log_in?#{%{t: "fake token"}}")
+    end
+
+    test "redirects if already logged in", %{conn: conn, client_code: client_code} do
+      conn = conn |> log_in_user(client_code)
+
+      {:error, {:redirect, %{to: "/"}}} =
+        live(conn, ~p"/magic_log_in?#{%{t: "doesn't matter"}}")
+    end
+
+    test "enters flow with a valid magic token", %{conn: conn, client_code: client_code} do
+      magic_token = Auth.generate_magic_token(client_code)
+      {:ok, _live, html} = live(conn, ~p"/magic_log_in?#{%{t: magic_token}}")
+
+      assert html =~ "Magic login"
+      assert html =~ "Your magic code is"
+      assert html =~ ~r/\d{6}/
+    end
+
+    test "submits form when event is received", %{conn: conn, client_code: client_code} do
+      magic_token = Auth.generate_magic_token(client_code)
+      {:ok, live, _html} = live(conn, ~p"/magic_log_in?#{%{t: magic_token}}")
+
+      login_token = Auth.generate_login_token(client_code)
+      send(live.pid, {:verified, %{login_token: login_token}})
+
+      assert live |> element("#redirect_form") |> render() =~ login_token
+
+      form = form(live, "#redirect_form", %{"login_token" => login_token})
+      conn = follow_trigger_action(form, conn)
+
+      assert redirected_to(conn) == ~p"/"
+      assert get_session(conn, :user_token)
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) == "Logged in magically!"
+    end
+
+    test "only logs in the LiveView for the code being verified", %{
+      conn: conn1,
+      client_code: client_code
+    } do
+      magic_token = Auth.generate_magic_token(client_code)
+      conn2 = build_conn()
+      {:ok, live1, _html} = live(conn1, ~p"/magic_log_in?#{%{t: magic_token}}")
+      {:ok, live2, _html} = live(conn2, ~p"/magic_log_in?#{%{t: magic_token}}")
+
+      login_token = Auth.generate_login_token(client_code)
+      send(live1.pid, {:verified, %{login_token: login_token}})
+
+      form1_html = live1 |> element("#redirect_form") |> render()
+      form2_html = live2 |> element("#redirect_form") |> render()
+
+      assert form1_html =~ login_token
+      assert form1_html =~ "phx-trigger-action"
+      refute form2_html =~ login_token
+      refute form2_html =~ "phx-trigger-action"
+    end
+  end
+end

--- a/test/slippi_chat_web/live/user_login_live_test.exs
+++ b/test/slippi_chat_web/live/user_login_live_test.exs
@@ -1,5 +1,5 @@
 defmodule SlippiChatWeb.UserLoginLiveTest do
-  use SlippiChatWeb.ConnCase, async: true
+  use SlippiChatWeb.ConnCase, async: false
 
   import Phoenix.LiveViewTest
   alias SlippiChat.Auth

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -34,7 +34,8 @@ defmodule SlippiChatWeb.ConnCase do
 
   setup tags do
     SlippiChat.DataCase.setup_sandbox(tags)
-    SlippiChat.Injections.set_chat_session_registry(tags.test)
+    SlippiChat.Injections.set_chat_session_registry(:"chat_session_registry #{tags.test}")
+    SlippiChat.Injections.set_magic_authenticator(:"magic_authenticator #{tags.test}")
 
     {:ok, conn: Phoenix.ConnTest.build_conn()}
   end

--- a/test/support/injections.ex
+++ b/test/support/injections.ex
@@ -14,4 +14,14 @@ defmodule SlippiChat.Injections do
       Application.put_env(:slippi_chat, :chat_session_registry, old_registry)
     end)
   end
+
+  def set_magic_authenticator(name) do
+    old_authenticator = Application.fetch_env!(:slippi_chat, :magic_authenticator)
+    ExUnit.Callbacks.start_supervised!({SlippiChat.Auth.MagicAuthenticator, name: name})
+    Application.put_env(:slippi_chat, :magic_authenticator, name)
+
+    ExUnit.Callbacks.on_exit(fn ->
+      Application.put_env(:slippi_chat, :magic_authenticator, old_authenticator)
+    end)
+  end
 end


### PR DESCRIPTION
An important part of SlippiChat is to be able to use the application in whatever way is convenient for users. For many users playing netplay on a single screen, this means using something like a phone for messaging. This means it must be easy to log in on a different device, and currently that is not the case because the sensitive client token is required to log in.

This PR adds a feature called "magic login" which generates a one-time login token for a device after a handshake is done with an already authenticated device (in this case, this is meant to be slippi-chat-client). 

Demo: https://youtu.be/z0-PPCp37eo