### PR TITLE
Create User model

### DIFF
--- a/lib/slippi_chat/auth.ex
+++ b/lib/slippi_chat/auth.ex
@@ -150,15 +150,16 @@ defmodule SlippiChat.Auth do
   ## Examples
 
     iex> register_user(%{field: value})
-    {:ok, %User{}}
+    {:ok, %User{}, "some_client_token"}
 
     iex> register_user(%{field: bad_value})
     {:error, %Ecto.Changeset{}}
 
   """
   def register_user(attrs) do
-    %User{}
-    |> User.registration_changeset(attrs)
-    |> Repo.insert()
+    with {:ok, user} <- %User{} |> User.registration_changeset(attrs) |> Repo.insert() do
+      token = generate_admin_client_token(user.connect_code)
+      {:ok, user, token}
+    end
   end
 end

--- a/lib/slippi_chat/auth.ex
+++ b/lib/slippi_chat/auth.ex
@@ -44,8 +44,8 @@ defmodule SlippiChat.Auth do
   """
   def generate_granted_client_token(client_code, granter_token) do
     with {:ok, query} <- ClientToken.verify_hashed_token_query(granter_token, "client"),
-         granter_code when not is_nil(granter_code) <- Repo.one(query) do
-      build_and_insert_client_token(client_code, granter_code)
+         granter when not is_nil(granter) <- Repo.one(query) do
+      build_and_insert_client_token(client_code, granter.connect_code)
     else
       _ -> :error
     end

--- a/lib/slippi_chat/auth.ex
+++ b/lib/slippi_chat/auth.ex
@@ -22,9 +22,9 @@ defmodule SlippiChat.Auth do
   end
 
   @doc """
-  Gets the connect code for the given signed token.
+  Gets the user for the given signed token.
   """
-  def get_client_code_by_session_token(token) do
+  def get_user_by_session_token(token) do
     {:ok, query} = ClientToken.verify_session_token_query(token)
     Repo.one(query)
   end
@@ -73,12 +73,12 @@ defmodule SlippiChat.Auth do
   end
 
   @doc """
-  Gets the client_code for the given client token.
+  Gets the user for the given client token.
 
   Returns `nil` if the token doesn't exist or isn't valid.
   """
-  def get_client_code_by_client_token(client_code) do
-    get_client_code_by_signed_token(client_code, "client")
+  def get_user_by_client_token(client_token) do
+    get_user_by_signed_token(client_token, "client")
   end
 
   @doc """
@@ -89,12 +89,12 @@ defmodule SlippiChat.Auth do
   end
 
   @doc """
-  Gets the client_code for the given magic token.
+  Gets the user for the given magic token.
 
   Returns `nil` if the token doesn't exist or isn't valid.
   """
-  def get_client_code_by_magic_token(client_code) do
-    get_client_code_by_signed_token(client_code, "magic")
+  def get_user_by_magic_token(magic_token) do
+    get_user_by_signed_token(magic_token, "magic")
   end
 
   @doc """
@@ -105,12 +105,12 @@ defmodule SlippiChat.Auth do
   end
 
   @doc """
-  Gets the client_code for the given login token.
+  Gets the user for the given login token.
 
   Returns `nil` if the token doesn't exist or isn't valid.
   """
-  def get_client_code_by_login_token(client_code) do
-    get_client_code_by_signed_token(client_code, "login")
+  def get_user_by_login_token(login_token) do
+    get_user_by_signed_token(login_token, "login")
   end
 
   @doc """
@@ -132,11 +132,11 @@ defmodule SlippiChat.Auth do
   end
 
   @doc """
-  Gets the client_code for the given signed token.
+  Gets the user for the given signed token.
 
   Returns `nil` if the token doesn't exist or isn't valid.
   """
-  def get_client_code_by_signed_token(token, context) do
+  def get_user_by_signed_token(token, context) do
     with {:ok, query} <- ClientToken.verify_hashed_token_query(token, context) do
       Repo.one(query)
     else

--- a/lib/slippi_chat/auth.ex
+++ b/lib/slippi_chat/auth.ex
@@ -8,7 +8,7 @@ defmodule SlippiChat.Auth do
   import Ecto.Query, warn: false
   alias SlippiChat.Repo
 
-  alias SlippiChat.Auth.{ClientToken, TokenGranter}
+  alias SlippiChat.Auth.{ClientToken, TokenGranter, User}
 
   ## Session
 
@@ -142,5 +142,23 @@ defmodule SlippiChat.Auth do
     else
       _ -> nil
     end
+  end
+
+  @doc """
+  Registers a user.
+
+  ## Examples
+
+    iex> register_user(%{field: value})
+    {:ok, %User{}}
+
+    iex> register_user(%{field: bad_value})
+    {:error, %Ecto.Changeset{}}
+
+  """
+  def register_user(attrs) do
+    %User{}
+    |> User.registration_changeset(attrs)
+    |> Repo.insert()
   end
 end

--- a/lib/slippi_chat/auth/client_token.ex
+++ b/lib/slippi_chat/auth/client_token.ex
@@ -1,6 +1,7 @@
 defmodule SlippiChat.Auth.ClientToken do
   use Ecto.Schema
   import Ecto.Query
+  alias SlippiChat.Auth.User
 
   @hash_algorithm :sha256
   @rand_size 32
@@ -52,8 +53,10 @@ defmodule SlippiChat.Auth.ClientToken do
   def verify_session_token_query(token) do
     query =
       from token in token_and_context_query(token, "session"),
+        join: user in User,
+        on: [connect_code: token.client_code],
         where: token.inserted_at > ago(@session_validity_in_days, "day"),
-        select: token.client_code
+        select: user
 
     {:ok, query}
   end
@@ -95,7 +98,9 @@ defmodule SlippiChat.Auth.ClientToken do
         query =
           from token in token_and_context_query(hashed_token, context),
             # where: token.inserted_at > ago(^days, "day") and token.sent_to == user.email,
-            select: token.client_code
+            join: user in User,
+            on: [connect_code: token.client_code],
+            select: user
 
         {:ok, query}
 

--- a/lib/slippi_chat/auth/user.ex
+++ b/lib/slippi_chat/auth/user.ex
@@ -1,0 +1,31 @@
+defmodule SlippiChat.Auth.User do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "users" do
+    field :connect_code, :string
+    field :is_admin, :boolean
+
+    timestamps()
+  end
+
+  @doc """
+  A user changeset for registration.
+  """
+  def registration_changeset(user, attrs) do
+    user
+    |> cast(attrs, [:connect_code, :is_admin])
+    |> validate_connect_code()
+  end
+
+  defp validate_connect_code(changeset) do
+    changeset
+    |> validate_required([:connect_code])
+    |> validate_format(:connect_code, ~r/^[A-Z]+#[[:digit:]]+$/,
+      message: "must be in the format ABC#123"
+    )
+    |> validate_length(:connect_code, max: 16)
+    |> unsafe_validate_unique(:connect_code, SlippiChat.Repo)
+    |> unique_constraint(:connect_code)
+  end
+end

--- a/lib/slippi_chat_web/channels/user_socket.ex
+++ b/lib/slippi_chat_web/channels/user_socket.ex
@@ -21,10 +21,10 @@ defmodule SlippiChatWeb.UserSocket do
   @impl true
   def connect(params, socket) do
     with token when not is_nil(token) <- params["client_token"],
-         client_code when not is_nil(client_code) <-
-           Auth.get_client_code_by_client_token(token) do
-      Logger.info("Socket connected for #{client_code}")
-      {:ok, assign(socket, :client_code, client_code)}
+         user when not is_nil(user) <-
+           Auth.get_user_by_client_token(token) do
+      Logger.info("Socket connected for #{user.connect_code}")
+      {:ok, assign(socket, :client_code, user.connect_code)}
     else
       _ -> :error
     end

--- a/lib/slippi_chat_web/components/layouts/root.html.heex
+++ b/lib/slippi_chat_web/components/layouts/root.html.heex
@@ -13,9 +13,9 @@
   </head>
   <body class="bg-white antialiased flex flex-col">
     <ul class="relative z-10 flex items-center gap-4 px-4 sm:px-6 lg:px-8 justify-end">
-      <%= if @current_user_code do %>
+      <%= if @current_user do %>
         <li class="text-[0.8125rem] leading-6 text-zinc-900">
-          <%= @current_user_code %>
+          <%= @current_user.connect_code %>
         </li>
         <li>
           <.link

--- a/lib/slippi_chat_web/controllers/magic_login_controller.ex
+++ b/lib/slippi_chat_web/controllers/magic_login_controller.ex
@@ -9,14 +9,14 @@ defmodule SlippiChatWeb.MagicLoginController do
   end
 
   def generate(conn, _params) do
-    client_code = conn.assigns[:current_user_code]
+    client_code = conn.assigns[:current_user].connect_code
     magic_token = Auth.generate_magic_token(client_code)
 
     render(conn, :show, magic_token: magic_token)
   end
 
   def verify(conn, %{"verification_code" => verification_code}) do
-    client_code = conn.assigns[:current_user_code]
+    client_code = conn.assigns[:current_user].connect_code
 
     if MagicAuthenticator.verify(magic_authenticator(), client_code, verification_code) do
       conn

--- a/lib/slippi_chat_web/controllers/user_session_controller.ex
+++ b/lib/slippi_chat_web/controllers/user_session_controller.ex
@@ -17,14 +17,14 @@ defmodule SlippiChatWeb.UserSessionController do
   end
 
   defp create(conn, %{"token" => token} = params, context, info) do
-    if client_code = Auth.get_client_code_by_signed_token(token, context) do
+    if user = Auth.get_user_by_signed_token(token, context) do
       if context == "login" do
-        Auth.delete_login_tokens(client_code)
+        Auth.delete_login_tokens(user.connect_code)
       end
 
       conn
       |> put_flash(:info, info)
-      |> UserAuth.log_in_user(client_code, params)
+      |> UserAuth.log_in_user(user.connect_code, params)
     else
       conn
       |> put_flash(:error, "Invalid token")

--- a/lib/slippi_chat_web/live/chat_live/root.ex
+++ b/lib/slippi_chat_web/live/chat_live/root.ex
@@ -83,7 +83,7 @@ defmodule SlippiChatWeb.ChatLive.Root do
 
   @impl true
   def mount(_params, _session, socket) do
-    code = socket.assigns.current_user_code
+    code = socket.assigns.current_user.connect_code
     player_code = SlippiChatWeb.Utils.game_player_code(code)
 
     socket =

--- a/lib/slippi_chat_web/live/magic_login_live.ex
+++ b/lib/slippi_chat_web/live/magic_login_live.ex
@@ -43,7 +43,7 @@ defmodule SlippiChatWeb.MagicLoginLive do
 
   @impl true
   def mount(%{"t" => magic_token}, _session, socket) do
-    if client_code = Auth.get_client_code_by_magic_token(magic_token) do
+    if client_code = Auth.get_user_by_magic_token(magic_token) do
       verification_code =
         if connected?(socket) do
           MagicAuthenticator.register_verification_code(magic_authenticator(), client_code)

--- a/lib/slippi_chat_web/router.ex
+++ b/lib/slippi_chat_web/router.ex
@@ -10,12 +10,12 @@ defmodule SlippiChatWeb.Router do
     plug :put_root_layout, {SlippiChatWeb.Layouts, :root}
     plug :protect_from_forgery
     plug :put_secure_browser_headers
-    plug :fetch_current_user_code
+    plug :fetch_current_user
   end
 
   pipeline :api do
     plug :accepts, ["json"]
-    plug :fetch_current_user_code
+    plug :fetch_current_user
   end
 
   scope "/", SlippiChatWeb do

--- a/lib/slippi_chat_web/user_auth.ex
+++ b/lib/slippi_chat_web/user_auth.ex
@@ -117,7 +117,7 @@ defmodule SlippiChatWeb.UserAuth do
 
   defp fetch_user_from_authorization(conn) do
     client_token = get_bearer_token(conn)
-    maybe_user = Auth.get_user_by_client_token(client_token)
+    maybe_user = client_token && Auth.get_user_by_client_token(client_token)
     assign(conn, :current_user, maybe_user)
   end
 

--- a/lib/slippi_chat_web/user_auth.ex
+++ b/lib/slippi_chat_web/user_auth.ex
@@ -88,17 +88,17 @@ defmodule SlippiChatWeb.UserAuth do
   Authenticates the user by looking into the session
   and remember me token.
   """
-  def fetch_current_user_code(conn, _opts) do
+  def fetch_current_user(conn, _opts) do
     case get_format(conn) do
-      "html" -> fetch_user_code_from_session(conn)
-      "json" -> fetch_user_code_from_authorization(conn)
+      "html" -> fetch_user_from_session(conn)
+      "json" -> fetch_user_from_authorization(conn)
     end
   end
 
-  defp fetch_user_code_from_session(conn) do
+  defp fetch_user_from_session(conn) do
     {user_token, conn} = ensure_user_token(conn)
-    connect_code = user_token && Auth.get_client_code_by_session_token(user_token)
-    assign(conn, :current_user_code, connect_code)
+    user = user_token && Auth.get_user_by_session_token(user_token)
+    assign(conn, :current_user, user)
   end
 
   defp ensure_user_token(conn) do
@@ -115,13 +115,10 @@ defmodule SlippiChatWeb.UserAuth do
     end
   end
 
-  defp fetch_user_code_from_authorization(conn) do
+  defp fetch_user_from_authorization(conn) do
     client_token = get_bearer_token(conn)
-
-    connect_code =
-      if client_token, do: Auth.get_client_code_by_client_token(client_token), else: nil
-
-    assign(conn, :current_user_code, connect_code)
+    maybe_user = Auth.get_user_by_client_token(client_token)
+    assign(conn, :current_user, maybe_user)
   end
 
   defp get_bearer_token(conn) do
@@ -173,7 +170,7 @@ defmodule SlippiChatWeb.UserAuth do
   def on_mount(:ensure_authenticated, _params, session, socket) do
     socket = mount_current_user(socket, session)
 
-    if socket.assigns.current_user_code do
+    if socket.assigns.current_user do
       {:cont, socket}
     else
       socket =
@@ -188,7 +185,7 @@ defmodule SlippiChatWeb.UserAuth do
   def on_mount(:redirect_if_user_is_authenticated, _params, session, socket) do
     socket = mount_current_user(socket, session)
 
-    if socket.assigns.current_user_code do
+    if socket.assigns.current_user do
       {:halt, Phoenix.LiveView.redirect(socket, to: signed_in_path(socket))}
     else
       {:cont, socket}
@@ -196,9 +193,9 @@ defmodule SlippiChatWeb.UserAuth do
   end
 
   defp mount_current_user(socket, session) do
-    Phoenix.Component.assign_new(socket, :current_user_code, fn ->
+    Phoenix.Component.assign_new(socket, :current_user, fn ->
       if user_token = session["user_token"] do
-        Auth.get_client_code_by_session_token(user_token)
+        Auth.get_user_by_session_token(user_token)
       end
     end)
   end
@@ -207,7 +204,7 @@ defmodule SlippiChatWeb.UserAuth do
   Used for routes that require the user to not be authenticated.
   """
   def redirect_if_user_is_authenticated(conn, _opts) do
-    if conn.assigns[:current_user_code] do
+    if conn.assigns[:current_user] do
       conn
       |> redirect(to: signed_in_path(conn))
       |> halt()
@@ -223,7 +220,7 @@ defmodule SlippiChatWeb.UserAuth do
   they use the application at all, here would be a good place.
   """
   def require_authenticated_user(conn, _opts) do
-    if conn.assigns[:current_user_code] do
+    if conn.assigns[:current_user] do
       conn
     else
       case get_format(conn) do

--- a/priv/repo/migrations/20250224100422_create_users.exs
+++ b/priv/repo/migrations/20250224100422_create_users.exs
@@ -1,0 +1,12 @@
+defmodule SlippiChat.Repo.Migrations.CreateUsers do
+  use Ecto.Migration
+
+  def change do
+    create table(:users) do
+      add :connect_code, :string, size: 16, null: false
+      add :is_admin, :boolean, null: false, default: false
+
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/migrations/20250224173750_retroactive_users.exs
+++ b/priv/repo/migrations/20250224173750_retroactive_users.exs
@@ -1,0 +1,25 @@
+defmodule SlippiChat.Repo.Migrations.RetroactiveUsers do
+  use Ecto.Migration
+  import Ecto.Query
+
+  alias SlippiChat.Repo
+  alias SlippiChat.Auth.User
+
+  def change do
+    clients_query =
+      from t in SlippiChat.Auth.ClientToken,
+        where: t.context == "client",
+        select: t.client_code
+
+    client_connect_codes = SlippiChat.Repo.all(clients_query)
+
+    Repo.transaction(fn ->
+      for connect_code <- client_connect_codes do
+        is_admin = connect_code == "WAFF#715"
+
+        %User{connect_code: connect_code, is_admin: is_admin}
+        |> Repo.insert!()
+      end
+    end)
+  end
+end

--- a/priv/repo/migrations/20250224173750_retroactive_users.exs
+++ b/priv/repo/migrations/20250224173750_retroactive_users.exs
@@ -7,9 +7,10 @@ defmodule SlippiChat.Repo.Migrations.RetroactiveUsers do
 
   def change do
     clients_query =
-      from t in SlippiChat.Auth.ClientToken,
+      from(t in SlippiChat.Auth.ClientToken,
         where: t.context == "client",
         select: t.client_code
+      )
 
     client_connect_codes = SlippiChat.Repo.all(clients_query)
 

--- a/test/slippi_chat/auth_test.exs
+++ b/test/slippi_chat/auth_test.exs
@@ -113,7 +113,9 @@ defmodule SlippiChat.AuthTest do
   describe "register_user/1" do
     test "registers a non-admin user" do
       connect_code = "ABC#123"
-      assert {:ok, user, token} = Auth.register_user(%{connect_code: connect_code, is_admin: false})
+
+      assert {:ok, user, token} =
+               Auth.register_user(%{connect_code: connect_code, is_admin: false})
 
       fetched_user = Repo.get(User, user.id)
       assert fetched_user.connect_code == connect_code
@@ -127,7 +129,9 @@ defmodule SlippiChat.AuthTest do
 
     test "registers an admin user" do
       connect_code = "ABC#123"
-      assert {:ok, user, token} = Auth.register_user(%{connect_code: connect_code, is_admin: true})
+
+      assert {:ok, user, token} =
+               Auth.register_user(%{connect_code: connect_code, is_admin: true})
 
       fetched_user = Repo.get(User, user.id)
       assert fetched_user.connect_code == connect_code
@@ -149,17 +153,32 @@ defmodule SlippiChat.AuthTest do
 
     test "ensures unique connect codes" do
       connect_code = "ABC#123"
-      assert {:ok, _user, _token} = Auth.register_user(%{connect_code: connect_code, is_admin: false})
-      assert {:error, _changeset} = Auth.register_user(%{connect_code: connect_code, is_admin: true})
+
+      assert {:ok, _user, _token} =
+               Auth.register_user(%{connect_code: connect_code, is_admin: false})
+
+      assert {:error, _changeset} =
+               Auth.register_user(%{connect_code: connect_code, is_admin: true})
     end
 
     test "ensures connect code format" do
-      assert {:ok, _user, _token} = Auth.register_user(%{connect_code: "LONGCODE#1234567", is_admin: false})
-      assert {:error, _changeset} = Auth.register_user(%{connect_code: "LONGCODE#12345678", is_admin: false})
-      assert {:error, _changeset} = Auth.register_user(%{connect_code: "NOPOUND123", is_admin: false})
-      assert {:error, _changeset} = Auth.register_user(%{connect_code: "lowerCASE#123", is_admin: false})
-      assert {:error, _changeset} = Auth.register_user(%{connect_code: "NONUMS#", is_admin: false})
-      assert {:ok, _user, _token} = Auth.register_user(%{connect_code: "COOLCODE#0", is_admin: false})
+      assert {:ok, _user, _token} =
+               Auth.register_user(%{connect_code: "LONGCODE#1234567", is_admin: false})
+
+      assert {:error, _changeset} =
+               Auth.register_user(%{connect_code: "LONGCODE#12345678", is_admin: false})
+
+      assert {:error, _changeset} =
+               Auth.register_user(%{connect_code: "NOPOUND123", is_admin: false})
+
+      assert {:error, _changeset} =
+               Auth.register_user(%{connect_code: "lowerCASE#123", is_admin: false})
+
+      assert {:error, _changeset} =
+               Auth.register_user(%{connect_code: "NONUMS#", is_admin: false})
+
+      assert {:ok, _user, _token} =
+               Auth.register_user(%{connect_code: "COOLCODE#0", is_admin: false})
     end
   end
 end

--- a/test/slippi_chat/auth_test.exs
+++ b/test/slippi_chat/auth_test.exs
@@ -1,5 +1,6 @@
 defmodule SlippiChat.AuthTest do
   use SlippiChat.DataCase, async: true
+  import SlippiChat.AuthFixtures
 
   alias SlippiChat.Auth
   alias SlippiChat.Auth.{ClientToken, TokenGranter, User}
@@ -26,52 +27,52 @@ defmodule SlippiChat.AuthTest do
     end
   end
 
-  describe "get_client_code_by_session_token/1" do
+  describe "get_user_by_session_token/1" do
     setup do
-      client_code = "ABC#123"
-      token = Auth.generate_user_session_token(client_code)
-      %{client_code: client_code, token: token}
+      user = user_fixture()
+      token = Auth.generate_user_session_token(user.connect_code)
+      %{user: user, token: token}
     end
 
-    test "returns client code by token", %{client_code: client_code, token: token} do
-      assert session_code = Auth.get_client_code_by_session_token(token)
-      assert session_code == client_code
+    test "returns  by token", %{user: user, token: token} do
+      assert session_user = Auth.get_user_by_session_token(token)
+      assert session_user == user
     end
 
-    test "does not return client code for invalid token" do
-      refute Auth.get_client_code_by_session_token("oops")
+    test "does not return user for invalid token" do
+      refute Auth.get_user_by_session_token("oops")
     end
 
-    test "does not return client code for expired token", %{token: token} do
-      {1, nil} = Repo.update_all(ClientToken, set: [inserted_at: ~N[2020-01-01 00:00:00]])
-      refute Auth.get_client_code_by_session_token(token)
+    test "does not return user for expired token", %{token: token} do
+      {_count, nil} = Repo.update_all(ClientToken, set: [inserted_at: ~N[2020-01-01 00:00:00]])
+      refute Auth.get_user_by_session_token(token)
     end
   end
 
   describe "delete_user_session_token/1" do
     test "deletes the token" do
-      client_code = "ABC#123"
-      token = Auth.generate_user_session_token(client_code)
+      user = user_fixture()
+      token = Auth.generate_user_session_token(user.connect_code)
       assert Auth.delete_user_session_token(token) == :ok
-      refute Auth.get_client_code_by_session_token(token)
+      refute Auth.get_user_by_session_token(token)
     end
   end
 
   describe "generate_granted_client_token/2" do
     test "generates a client token" do
-      granter_code = "ABC#123"
-      granter_token = Auth.generate_admin_client_token(granter_code)
+      granter = user_fixture()
+      granter_token = Auth.generate_admin_client_token(granter.connect_code)
 
-      client_code = "DEF#456"
-      token = Auth.generate_granted_client_token(client_code, granter_token)
+      grantee = user_fixture()
+      token = Auth.generate_granted_client_token(grantee.connect_code, granter_token)
       {:ok, token} = Base.url_decode64(token, padding: false)
 
       assert client_token = Repo.get_by(ClientToken, token: :crypto.hash(:sha256, token))
       assert client_token.context == "client"
-      assert client_token.client_code == client_code
+      assert client_token.client_code == grantee.connect_code
 
-      assert granter = Repo.get_by(TokenGranter, client_token_id: client_token.id)
-      assert granter.granter_code == granter_code
+      assert token_grant = Repo.get_by(TokenGranter, client_token_id: client_token.id)
+      assert token_grant.granter_code == granter.connect_code
     end
 
     test "does not generate a token with an invalid granter token" do
@@ -91,18 +92,18 @@ defmodule SlippiChat.AuthTest do
     end
   end
 
-  describe "get_client_code_by_signed_token/2" do
-    test "returns the client code for a valid token" do
-      client_code = "ABC#123"
-      token = Auth.generate_admin_client_token(client_code)
+  describe "get_user_by_signed_token/2" do
+    test "returns the user for a valid token" do
+      user = user_fixture()
+      token = Auth.generate_admin_client_token(user.connect_code)
 
-      assert Auth.get_client_code_by_signed_token(token, "client") == client_code
+      assert Auth.get_user_by_signed_token(token, "client") == user
     end
 
     test "returns `nil` for an invalid token" do
-      assert Auth.get_client_code_by_signed_token(":)", "client") == nil
+      assert Auth.get_user_by_signed_token(":)", "client") == nil
 
-      assert Auth.get_client_code_by_signed_token(
+      assert Auth.get_user_by_signed_token(
                Base.url_encode64(":)", padding: false),
                "client"
              ) == nil

--- a/test/slippi_chat_web/channels/user_socket_test.exs
+++ b/test/slippi_chat_web/channels/user_socket_test.exs
@@ -1,5 +1,6 @@
 defmodule SlippiChatWeb.UserSocketTest do
   use SlippiChatWeb.ChannelCase, async: false
+  import SlippiChat.AuthFixtures
 
   alias SlippiChat.Auth
   alias SlippiChatWeb.UserSocket
@@ -10,11 +11,11 @@ defmodule SlippiChatWeb.UserSocketTest do
 
   describe "connect" do
     test "requires a client token", %{socket: socket} do
-      client_code = "ABC#123"
-      client_token = Auth.generate_admin_client_token(client_code)
+      user = user_fixture()
+      client_token = Auth.generate_admin_client_token(user.connect_code)
 
       assert {:ok, socket} = UserSocket.connect(%{"client_token" => client_token}, socket)
-      assert socket.assigns.client_code == client_code
+      assert socket.assigns.client_code == user.connect_code
     end
 
     test "refuses connection with no token specified", %{socket: socket} do

--- a/test/slippi_chat_web/live/game_live/root_test.exs
+++ b/test/slippi_chat_web/live/game_live/root_test.exs
@@ -3,6 +3,7 @@ defmodule SlippiChatWeb.GameLive.RootTest do
 
   import Phoenix.LiveViewTest
   import Phoenix.ChannelTest
+  import SlippiChat.AuthFixtures
 
   alias SlippiChatWeb.Endpoint
   alias SlippiChat.ChatSessionRegistry
@@ -18,8 +19,8 @@ defmodule SlippiChatWeb.GameLive.RootTest do
   end
 
   defp authenticate(%{conn: conn}) do
-    client_code = "ABC#123"
-    %{conn: log_in_user(conn, client_code), client_code: client_code}
+    user = user_fixture(%{connect_code: "ABC#123"})
+    %{conn: log_in_user(conn, user.connect_code), client_code: user.connect_code}
   end
 
   describe "Mount" do
@@ -67,6 +68,7 @@ defmodule SlippiChatWeb.GameLive.RootTest do
       player_codes = ["ABC#123", "XYZ#987"]
       {:ok, _pid} = ChatSessionRegistry.start_chat_session(chat_session_registry(), player_codes)
 
+      _user2 = user_fixture(%{connect_code: "XYZ#987"})
       conn2 = Phoenix.ConnTest.build_conn() |> log_in_user("XYZ#987")
       {:ok, lv1, _html1} = live(conn1, ~p"/chat")
       {:ok, lv2, _html2} = live(conn2, ~p"/chat")
@@ -116,6 +118,7 @@ defmodule SlippiChatWeb.GameLive.RootTest do
       {:ok, _pid} = ChatSessionRegistry.start_chat_session(chat_session_registry(), player_codes)
       Endpoint.subscribe("clients")
 
+      _user2 = user_fixture(%{connect_code: "XYZ#987"})
       conn2 = Phoenix.ConnTest.build_conn() |> log_in_user("XYZ#987")
       {:ok, lv1, html1} = live(conn1, ~p"/chat")
       {:ok, lv2, html2} = live(conn2, ~p"/chat")

--- a/test/slippi_chat_web/live/user_login_live_test.exs
+++ b/test/slippi_chat_web/live/user_login_live_test.exs
@@ -2,6 +2,8 @@ defmodule SlippiChatWeb.UserLoginLiveTest do
   use SlippiChatWeb.ConnCase, async: false
 
   import Phoenix.LiveViewTest
+  import SlippiChat.AuthFixtures
+
   alias SlippiChat.Auth
 
   describe "Log in page" do
@@ -12,9 +14,11 @@ defmodule SlippiChatWeb.UserLoginLiveTest do
     end
 
     test "redirects if already logged in", %{conn: conn} do
+      user = user_fixture()
+
       result =
         conn
-        |> log_in_user("ABC#123")
+        |> log_in_user(user.connect_code)
         |> live(~p"/log_in")
         |> follow_redirect(conn, "/")
 
@@ -24,7 +28,8 @@ defmodule SlippiChatWeb.UserLoginLiveTest do
 
   describe "user login" do
     test "redirects if user login with valid credentials", %{conn: conn} do
-      token = Auth.generate_admin_client_token("ABC#123")
+      user = user_fixture()
+      token = Auth.generate_admin_client_token(user.connect_code)
 
       {:ok, lv, _html} = live(conn, ~p"/log_in")
 

--- a/test/slippi_chat_web/user_auth_test.exs
+++ b/test/slippi_chat_web/user_auth_test.exs
@@ -116,7 +116,9 @@ defmodule SlippiChatWeb.UserAuthTest do
 
     test "authenticates user from cookies", %{conn: conn, user: user} do
       logged_in_conn =
-        conn |> fetch_cookies() |> UserAuth.log_in_user(user.connect_code, %{"remember_me" => "true"})
+        conn
+        |> fetch_cookies()
+        |> UserAuth.log_in_user(user.connect_code, %{"remember_me" => "true"})
 
       user_token = logged_in_conn.cookies[@remember_me_cookie]
       %{value: signed_token} = logged_in_conn.resp_cookies[@remember_me_cookie]

--- a/test/support/fixtures/auth_fixtures.ex
+++ b/test/support/fixtures/auth_fixtures.ex
@@ -1,0 +1,40 @@
+defmodule SlippiChat.AuthFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `SlippiChat.Auth` context.
+  """
+  alias SlippiChat.Repo
+  alias SlippiChat.Auth.User
+  import Ecto.Query
+
+  defp random_connect_code do
+    letters = for _ <- 1..4, into: "", do: <<Enum.random(?A..?Z)>>
+    number = :rand.uniform(1000) - 1
+    "#{letters}##{number}"
+  end
+
+  defp unique_connect_code do
+    generated_connect_code = random_connect_code()
+
+    if Repo.exists?(from u in User, where: u.connect_code == ^generated_connect_code) do
+      unique_connect_code()
+    else
+      generated_connect_code
+    end
+  end
+
+  def valid_user_attributes(attrs \\ %{}) do
+    connect_code = unique_connect_code()
+
+    Enum.into(attrs, %{
+      connect_code: connect_code,
+      is_admin: false
+    })
+  end
+
+  def user_fixture(attrs \\ %{}) do
+    valid_attrs = valid_user_attributes(attrs)
+    {:ok, user, _token} = SlippiChat.Auth.register_user(valid_attrs)
+    user
+  end
+end


### PR DESCRIPTION
This PR creates a `User` model with two fields: `connect_code` and `is_admin`.

Previously, the concept of a user was loosely defined: it was essentially just the connect code associated to a client token, which may be why it originally did not seem worthwhile to have its own table and model. There also was a notion of keeping as much as possible outside the database which enabled this decision.

However, the lack of a real model has some drawbacks:
- It is not possible to associate persistent metadata with a connect code, or at least it must be done elsewhere. If it were implemented elsewhere, this would most likely lead to an unnecessarily fragmented data model.
- It feels as if there is no source of truth for registered users, when in fact there is. It simply does not model the system in the most simple and accurate way.

---

The motivating factor for finally adding this model is the want to differentiate between admin and non-admin users, for the purpose of determining who has the right to grant tokens (and therefore, who has the right to access the future token creation page). 

What this PR does **not** do:
- Create foreign key links between `clients_tokens` and `users` tables
- Link to the user model within the message model
- Deal with or modify token granting logic at all